### PR TITLE
 feat(mobile-frontend): add auth and websocket service layer 

### DIFF
--- a/Apps/tablet_app/lib/services/auth_service.dart
+++ b/Apps/tablet_app/lib/services/auth_service.dart
@@ -1,0 +1,375 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart';
+
+/// Handles authentication, persisted session state, and authenticated API calls.
+class AuthService {
+  /// Backend URL override supplied at build time through TABLET_BACKEND_URL.
+  static const String _envBaseUrl = String.fromEnvironment(
+    'TABLET_BACKEND_URL',
+    defaultValue: '',
+  );
+
+  /// Returns the tablet backend base URL for the current build mode.
+  static String get baseUrl {
+    if (_envBaseUrl.isNotEmpty) return _envBaseUrl;
+    if (kReleaseMode) return 'https://legislanet.com.br/tablet-api';
+    return 'http://127.0.0.1:3001';
+  }
+
+  /// Current bearer token used for authenticated requests.
+  static String? _token;
+
+  /// Current authenticated user payload returned by the backend.
+  static Map<String, dynamic>? _currentUser;
+
+  /// Prevents concurrent login attempts during automatic re-authentication.
+  static bool _isRelogging = false;
+
+  /// Returns the current authenticated user payload, if available.
+  static Map<String, dynamic>? get currentUser => _currentUser;
+
+  /// Returns the current bearer token, if available.
+  static String? get token => _token;
+
+  /// Whether a token and user payload are loaded in memory.
+  static bool get isLoggedIn => _token != null && _currentUser != null;
+
+  /// Attempts to restore a persisted session from the device.
+  ///
+  /// Returns `true` when a cached session is valid or automatic re-login
+  /// succeeds. Expired sessions are cleared when re-login is not possible.
+  static Future<bool> tryAutoLogin() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (!prefs.containsKey('userData')) return false;
+
+      final extractedUserData =
+          json.decode(prefs.getString('userData')!) as Map<String, dynamic>;
+
+      _token = extractedUserData['token'];
+      _currentUser = extractedUserData['user'];
+
+      print('💾 [AuthService] Sessão restaurada do cache local');
+
+      final isValid = await validateToken();
+      if (!isValid) {
+        print('⚠️ [AuthService] Token expirado, tentando re-login...');
+
+        final credentials = prefs.getString('credentials');
+        if (credentials != null) {
+          try {
+            final creds = json.decode(credentials) as Map<String, dynamic>;
+            final result = await login(creds['email'], creds['password']);
+            if (result['success'] == true) {
+              print('✅ [AuthService] Re-login automático bem-sucedido');
+              return true;
+            }
+          } catch (e) {
+            print('❌ [AuthService] Falha no re-login: $e');
+          }
+        }
+
+        await logout();
+        return false;
+      }
+
+      return true;
+    } catch (e) {
+      print('❌ [AuthService] Falha ao restaurar sessão: $e');
+      return false;
+    }
+  }
+
+  /// Authenticates a council member and persists the session on the device.
+  ///
+  /// The [email] and [password] are sent to the login endpoint. A successful
+  /// response must contain a user with the `vereador` role.
+  static Future<Map<String, dynamic>> login(
+    String email,
+    String password,
+  ) async {
+    if (_isRelogging) {
+      return {'success': false, 'error': 'Re-login em andamento'};
+    }
+
+    final url = '$baseUrl/api/auth/login';
+    print('🔐 [AuthService] Tentando login em: $url');
+
+    try {
+      final response = await http.post(
+        Uri.parse(url),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'email': email, 'password': password}),
+      );
+
+      print('📡 [AuthService] Status: ${response.statusCode}');
+      final responseData = jsonDecode(response.body);
+
+      if (response.statusCode == 200) {
+        _token = responseData['token'];
+        _currentUser = responseData['user'];
+
+        if (_currentUser?['role'] != 'vereador') {
+          throw Exception('Acesso restrito a vereadores');
+        }
+
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString(
+          'userData',
+          json.encode({'token': _token, 'user': _currentUser}),
+        );
+        await prefs.setString(
+          'credentials',
+          json.encode({'email': email, 'password': password}),
+        );
+
+        return {'success': true, 'user': _currentUser, 'token': _token};
+      } else {
+        return {
+          'success': false,
+          'error': responseData['error'] ?? 'Erro desconhecido',
+        };
+      }
+    } catch (e) {
+      print('❌ [AuthService] Erro de conexão: $e');
+      return {'success': false, 'error': 'Erro de conexão: ${e.toString()}'};
+    }
+  }
+
+  /// Fetches the full profile for the currently authenticated council member.
+  static Future<Map<String, dynamic>?> getVereadorDetails() async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/vereador/profile'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('❌ [AuthService] Erro ao buscar perfil: $e');
+    }
+    return null;
+  }
+
+  /// Logs out from the backend and clears persisted local session data.
+  static Future<void> logout() async {
+    if (_token != null) {
+      try {
+        await http.post(
+          Uri.parse('$baseUrl/api/auth/logout'),
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer $_token',
+          },
+        );
+      } catch (e) {
+        print('Erro ao fazer logout no servidor: $e');
+      }
+    }
+
+    _token = null;
+    _currentUser = null;
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+  }
+
+  /// Checks whether the current token is still accepted by the backend.
+  ///
+  /// Network failures are treated as non-fatal so an offline device does not
+  /// immediately lose its cached session.
+  static Future<bool> validateToken() async {
+    if (!isLoggedIn) return false;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/vereador/profile'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 401 || response.statusCode == 403) {
+        return false;
+      }
+      return true;
+    } catch (e) {
+      print('⚠️ [AuthService] Erro ao validar token (offline): $e');
+      return true;
+    }
+  }
+
+  /// Fetches paginated agenda items for the council chamber.
+  ///
+  /// The [page] and [limit] values are forwarded as query parameters.
+  static Future<Map<String, dynamic>?> getPautas({
+    int page = 1,
+    int limit = 50,
+  }) async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/pautas?page=$page&limit=$limit'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('❌ [AuthService] Erro ao buscar pautas: $e');
+    }
+    return null;
+  }
+
+  /// Fetches one agenda item by [pautaId].
+  static Future<Map<String, dynamic>?> getPautaById(String pautaId) async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/pautas/$pautaId'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('❌ [AuthService] Erro ao buscar pauta por ID: $e');
+    }
+    return null;
+  }
+
+  /// Registers the authenticated council member vote for an agenda item.
+  ///
+  /// Sends [voto] for the agenda identified by [pautaId].
+  static Future<Map<String, dynamic>?> registrarVoto(
+    String pautaId,
+    String voto,
+  ) async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/api/votos'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+        body: jsonEncode({'pauta_id': pautaId, 'voto': voto}),
+      );
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        return jsonDecode(response.body);
+      } else {
+        final errorData = jsonDecode(response.body);
+        return {
+          'success': false,
+          'error': errorData['error'] ?? 'Erro ao registrar voto',
+        };
+      }
+    } catch (e) {
+      print('❌ [AuthService] Erro ao registrar voto: $e');
+      return {'success': false, 'error': 'Erro de conexão: $e'};
+    }
+  }
+
+  /// Fetches all votes already cast by the authenticated council member.
+  static Future<Map<String, dynamic>?> getVotosVereador() async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/votos/meus-votos'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('❌ [AuthService] Erro ao buscar votos: $e');
+    }
+    return null;
+  }
+
+  /// Fetches vote statistics for the agenda identified by [pautaId].
+  static Future<Map<String, dynamic>?> getEstatisticasPauta(
+    String pautaId,
+  ) async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/votos/pauta/$pautaId/estatisticas'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('❌ [AuthService] Erro ao buscar estatísticas: $e');
+    }
+    return null;
+  }
+
+  /// Fetches live voting status for the chamber identified by [camaraId].
+  ///
+  /// This is a best-effort call used by the dashboard to confirm which agenda
+  /// items are actively live.
+  static Future<Map<String, dynamic>?> getLiveVotingStatus(
+    String camaraId,
+  ) async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/votacao-ao-vivo/status/$camaraId'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('⚠️ [AuthService] getLiveVotingStatus indisponível: $e');
+    }
+    return null;
+  }
+
+  /// Fetches the authenticated council member vote for one agenda item.
+  static Future<Map<String, dynamic>?> getVotoEmPauta(String pautaId) async {
+    if (!isLoggedIn) return null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/votos/pauta/$pautaId'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $_token',
+        },
+      );
+
+      if (response.statusCode == 200) return jsonDecode(response.body);
+    } catch (e) {
+      print('❌ [AuthService] Erro ao buscar voto em pauta: $e');
+    }
+    return null;
+  }
+}

--- a/Apps/tablet_app/lib/services/websocket_service.dart
+++ b/Apps/tablet_app/lib/services/websocket_service.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+/// Stub WebSocket service that preserves the production service API.
+///
+/// This implementation emits no socket-driven domain events so the app can
+/// continue operating through HTTP polling until the Socket.IO integration is
+/// implemented.
+class WebSocketService {
+  /// Shared singleton instance.
+  static final WebSocketService _instance = WebSocketService._internal();
+
+  /// Creates the internal singleton instance.
+  WebSocketService._internal();
+
+  /// Returns the shared WebSocket service instance.
+  static WebSocketService get instance => _instance;
+
+  /// Whether the stub currently reports an active connection.
+  bool _connected = false;
+
+  /// Whether the service is currently connected.
+  bool get isConnected => _connected;
+
+  /// Controller for agenda status updates.
+  final _pautaStatusController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  /// Controller for voting-start events.
+  final _iniciarVotacaoController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  /// Controller for voting-finished events.
+  final _encerrarVotacaoController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  /// Controller for newly created agenda events.
+  final _novaPautaController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  /// Controller for connection status changes.
+  final _connectionController = StreamController<String>.broadcast();
+
+  /// Controller for vote notification events.
+  final _votoNotificationsController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  /// Controller for live statistics updates.
+  final _statsUpdatesController =
+      StreamController<Map<String, dynamic>>.broadcast();
+
+  /// Stream of agenda status updates.
+  Stream<Map<String, dynamic>> get pautaStatusUpdates =>
+      _pautaStatusController.stream;
+
+  /// Stream of voting-start events.
+  Stream<Map<String, dynamic>> get iniciarVotacaoEvents =>
+      _iniciarVotacaoController.stream;
+
+  /// Stream of voting-finished events.
+  Stream<Map<String, dynamic>> get encerrarVotacaoEvents =>
+      _encerrarVotacaoController.stream;
+
+  /// Stream of newly created agenda events.
+  Stream<Map<String, dynamic>> get novaPautaEvents =>
+      _novaPautaController.stream;
+
+  /// Stream of connection status values.
+  Stream<String> get connectionStatus => _connectionController.stream;
+
+  /// Stream of vote notification events.
+  Stream<Map<String, dynamic>> get votoNotifications =>
+      _votoNotificationsController.stream;
+
+  /// Stream of live statistics updates.
+  Stream<Map<String, dynamic>> get statsUpdates =>
+      _statsUpdatesController.stream;
+
+  /// Marks the stub as connected so the app can continue through HTTP polling.
+  Future<void> connect() async {
+    print('[WebSocketService] STUB — operando via HTTP polling.');
+    _connected = true;
+    _connectionController.add('connected');
+  }
+
+  /// Marks the stub as disconnected.
+  void disconnect() {
+    _connected = false;
+  }
+
+  /// Accepts a [context] for API compatibility with the real implementation.
+  void setContext(BuildContext context) {
+  }
+
+  /// Keeps the agenda-room API available until Socket.IO support is added.
+  void joinPauta(String pautaId) {
+    print('[WebSocketService] STUB — joinPauta($pautaId) sem efeito.');
+  }
+
+  /// Keeps the agenda-room leave API available until Socket.IO support is added.
+  void leavePauta(String pautaId) {
+    print('[WebSocketService] STUB — leavePauta($pautaId) sem efeito.');
+  }
+
+  /// Closes all stream controllers owned by this service.
+  void dispose() {
+    _pautaStatusController.close();
+    _iniciarVotacaoController.close();
+    _encerrarVotacaoController.close();
+    _novaPautaController.close();
+    _connectionController.close();
+    _votoNotificationsController.close();
+    _statsUpdatesController.close();
+  }
+}


### PR DESCRIPTION
Implements the core communication services for the Flutter tablet application. AuthService centralizes all HTTP communication with the tablet backend including login, logout, auto-login with token revalidation, session persistence via SharedPreferences, and all data endpoints (pautas, votos, estatisticas, live voting status). WebSocketService delivers a fully API-compatible stub with broadcast streams and singleton pattern, exposing all stream contracts required by the dashboard and voting screens, prepared for Socket.IO integration in the upcoming integration sprint.