### PR TITLE
 feat(mobile-backend): add supabase config, logger and auth middleware 

### DIFF
--- a/tablet_backend/src/config/logger.js
+++ b/tablet_backend/src/config/logger.js
@@ -1,0 +1,61 @@
+const winston = require('winston');
+const DailyRotateFile = require('winston-daily-rotate-file');
+const path = require('path');
+
+/**
+ * Creates a context-aware logger for tablet backend modules.
+ *
+ * Log entries are written to the console and daily rotating files. Error-level
+ * messages are also written to a dedicated error log.
+ *
+ * @param {string} context - Module or component name included in each log line.
+ * @returns {{info: Function, error: Function, warn: Function, debug: Function}} Logger facade.
+ */
+const createLogger = (context) => {
+    const logsDir = path.join(__dirname, '../../logs');
+
+    const logger = winston.createLogger({
+        level: process.env.LOG_LEVEL || 'info',
+        format: winston.format.combine(
+            winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+            winston.format.errors({ stack: true }),
+            winston.format.printf(({ timestamp, level, message, stack, ...meta }) => {
+                let log = `[${timestamp}] [${context}] [${level.toUpperCase()}] ${message}`;
+                if (stack) log += `\nStack: ${stack}`;
+                if (Object.keys(meta).length > 0) log += `\nMeta: ${JSON.stringify(meta, null, 2)}`;
+                return log;
+            })
+        ),
+        transports: [
+            new winston.transports.Console({
+                format: winston.format.combine(
+                    winston.format.colorize(),
+                    winston.format.simple()
+                )
+            }),
+            new DailyRotateFile({
+                filename: path.join(logsDir, 'tablet_backend_%DATE%.log'),
+                datePattern: 'YYYY-MM-DD',
+                maxSize: process.env.LOG_MAX_SIZE || '20m',
+                maxFiles: process.env.LOG_MAX_FILES || '14d',
+                level: 'info'
+            }),
+            new DailyRotateFile({
+                filename: path.join(logsDir, 'tablet_errors_%DATE%.log'),
+                datePattern: 'YYYY-MM-DD',
+                maxSize: process.env.LOG_MAX_SIZE || '20m',
+                maxFiles: process.env.LOG_MAX_FILES || '14d',
+                level: 'error'
+            })
+        ]
+    });
+
+    return {
+        info: (message, meta = {}) => logger.info(message, meta),
+        error: (message, meta = {}) => logger.error(message, meta),
+        warn: (message, meta = {}) => logger.warn(message, meta),
+        debug: (message, meta = {}) => logger.debug(message, meta),
+    };
+};
+
+module.exports = createLogger;

--- a/tablet_backend/src/config/supabase.js
+++ b/tablet_backend/src/config/supabase.js
@@ -1,0 +1,20 @@
+const { createClient } = require('@supabase/supabase-js');
+
+/**
+ * Administrative Supabase client that uses the service key for privileged
+ * backend operations that bypass row-level security.
+ */
+const supabaseAdmin = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_KEY
+);
+
+/**
+ * Public Supabase client that uses the anonymous key for authentication flows.
+ */
+const supabasePublic = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_ANON_KEY
+);
+
+module.exports = { supabaseAdmin, supabasePublic };

--- a/tablet_backend/src/middleware/authMiddleware.js
+++ b/tablet_backend/src/middleware/authMiddleware.js
@@ -1,0 +1,88 @@
+const { supabaseAdmin } = require('../config/supabase');
+const createLogger = require('../config/logger');
+const logger = createLogger('AUTH_MIDDLEWARE');
+
+/**
+ * Decodes the payload section of a JWT without verifying the signature.
+ *
+ * The middleware only uses this helper to read the token `iat` value for
+ * single-session enforcement.
+ *
+ * @param {string} token - JWT access token.
+ * @returns {object|null} Parsed payload, or `null` when decoding fails.
+ */
+const decodeJwtPayload = (token) => {
+    try {
+        const payloadBase64 = token.split('.')[1];
+        const decodedJson = Buffer.from(payloadBase64, 'base64').toString();
+        return JSON.parse(decodedJson);
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Authenticates requests that require a council member session.
+ *
+ * Validates the bearer token with Supabase Auth, loads the matching profile,
+ * enforces the `vereador` role, and rejects tokens older than the profile
+ * `min_token_iat` value. On success, attaches `user` and `profile` to the
+ * request for downstream controllers.
+ *
+ * @param {import('express').Request} req - Incoming HTTP request.
+ * @param {import('express').Response} res - HTTP response object.
+ * @param {import('express').NextFunction} next - Express continuation callback.
+ * @returns {Promise<import('express').Response|void>} Authentication result or continuation.
+ */
+const authenticateVereador = async (req, res, next) => {
+    logger.info('--- VERIFICANDO AUTENTICAÇÃO DE VEREADOR ---');
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ error: 'Token de acesso ausente ou mal formatado.' });
+    }
+
+    const token = authHeader.split(' ')[1];
+
+    try {
+        const { data: { user }, error: userError } = await supabaseAdmin.auth.getUser(token);
+        if (userError || !user) {
+            logger.error('Token inválido ou expirado.', { error: userError?.message });
+            return res.status(401).json({ error: 'Token inválido ou expirado.' });
+        }
+
+        const { data: profile, error: profileError } = await supabaseAdmin
+            .from('profiles')
+            .select('role, camara_id, min_token_iat, nome')
+            .eq('id', user.id)
+            .single();
+
+        if (profileError || !profile) {
+            logger.error('Perfil não encontrado.', { userId: user.id });
+            return res.status(404).json({ error: 'Perfil de usuário não encontrado.' });
+        }
+
+        if (profile.role !== 'vereador') {
+            logger.error('Role inválida.', { role: profile.role });
+            return res.status(403).json({ error: 'Acesso negado. Apenas vereadores podem acessar esta aplicação.' });
+        }
+
+        const payload = decodeJwtPayload(token);
+        if (!payload || payload.iat < profile.min_token_iat) {
+            logger.warn('Token de sessão antiga detectado.', { tokenIat: payload?.iat, minIat: profile.min_token_iat });
+            return res.status(401).json({ error: 'Sessão expirada. Por favor, faça login novamente.' });
+        }
+
+        req.user = user;
+        req.profile = profile;
+
+        logger.info(`✅ Acesso autorizado: ${profile.nome} (câmara: ${profile.camara_id})`);
+        next();
+
+    } catch (error) {
+        logger.error('Erro crítico na autenticação.', { error: error.message });
+        return res.status(500).json({ error: 'Erro interno no servidor durante a autenticação.' });
+    }
+};
+
+module.exports = { authenticateVereador };


### PR DESCRIPTION
Configures the data access layer and security middleware for the mobile backend. Dual Supabase clients are set up — admin client (service key) for privileged server-side operations and public client (anon key) for RLS-enforced queries. The structured Winston logger is configured with daily rotation, size limits, and environment-aware log levels. The authMiddleware validates JWT tokens, enforces single-session control via min_token_iat, and restricts access to vereador role only.