### PR TITLE
 feat(mobile-frontend): sync dashboard and voting screens with final version 

### DIFF
--- a/tablet_app/lib/dashboard_vereador_screen.dart
+++ b/tablet_app/lib/dashboard_vereador_screen.dart
@@ -1,90 +1,970 @@
 import 'package:flutter/material.dart';
-import 'votacao_pauta_screen.dart'; // Importação Relativa da nova tela
+import 'votacao_pauta_screen.dart';
+import 'services/auth_service.dart';
+import 'services/websocket_service.dart';
+import 'dart:async';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
-/// Defines the possible voting states that can be displayed for a council
-/// member.
-///
-/// This enum is used by the dashboard cards to determine the label and visual
-/// styling shown for the current user's vote.
+/// Vote states shown in agenda cards for the current council member.
 enum VotoTipo { sim, nao, abstencao, naoVotado }
 
-/// Displays the council member dashboard with ongoing and completed votes.
-///
-/// This screen shows a greeting header, a toggle to switch between voting
-/// sections, and the corresponding list of voting cards for the selected view.
+/// Dashboard tabs used to group agenda items by voting status.
+enum TabState { pendente, emVotacao, finalizada }
+
+/// Dashboard screen for council members to review agendas and enter voting.
 class DashboardVereadorScreen extends StatefulWidget {
-  /// Creates a dashboard screen for the council member area.
-  ///
-  /// Args:
-  ///   key: The widget key used to control how this widget replaces another
-  ///     widget in the tree.
+  /// Creates the council member dashboard.
   const DashboardVereadorScreen({super.key});
 
   @override
-  /// Creates the mutable state for [DashboardVereadorScreen].
-  ///
-  /// Returns:
-  ///   A [_DashboardVereadorScreenState] instance that manages the selected
-  ///   dashboard tab.
   State<DashboardVereadorScreen> createState() =>
       _DashboardVereadorScreenState();
 }
 
-/// Holds the UI state for [DashboardVereadorScreen].
-///
-/// This state object manages whether the dashboard is showing ongoing votes or
-/// completed votes.
+/// Manages agenda loading, live voting events, and dashboard presentation.
 class _DashboardVereadorScreenState extends State<DashboardVereadorScreen> {
-  bool _showFinalizadas = false;
+  /// Currently selected dashboard tab.
+  TabState _currentTab = TabState.pendente;
 
+  /// Current WebSocket connection state used by the connection indicator.
+  String _connectionStatus = 'connected';
+
+  /// Authenticated council member data displayed in the header.
+  Map<String, dynamic>? _vereadorData;
+
+  /// Tracks whether council member data is currently loading.
+  bool _isLoadingVereador = true;
+
+  /// Cached agenda items grouped as pending.
+  List<Map<String, dynamic>> _pautasPendentes = [];
+
+  /// Cached agenda items currently open for voting.
+  List<Map<String, dynamic>> _pautasEmVotacao = [];
+
+  /// Cached agenda items with completed voting.
+  List<Map<String, dynamic>> _pautasFinalizadas = [];
+
+  /// Tracks whether the first agenda page is loading.
+  bool _isLoadingPautas = true;
+
+  /// Tracks whether another agenda page is loading through pagination.
+  bool _isLoadingMorePautas = false;
+
+  /// Current agenda page loaded from the backend.
+  int _pautasPage = 1;
+
+  /// Total agenda pages reported by the backend.
+  int _pautasTotalPages = 1;
+
+  /// Agenda cache keyed by agenda ID to merge paginated and real-time updates.
+  final Map<String, Map<String, dynamic>> _pautasById = {};
+
+  /// Vote cache keyed by agenda ID for the current council member.
+  final Map<String, Map<String, dynamic>> _votosVereador =
+      {};
+
+  /// Shared WebSocket service used for dashboard live updates.
+  final WebSocketService _webSocketService = WebSocketService.instance;
+
+  /// Subscription for agenda status update events.
+  StreamSubscription<Map<String, dynamic>>? _pautaStatusSubscription;
+
+  /// Subscription for events that start voting on an agenda.
+  StreamSubscription<Map<String, dynamic>>? _iniciarVotacaoSubscription;
+
+  /// Subscription for events that finish voting on an agenda.
+  StreamSubscription<Map<String, dynamic>>? _encerrarVotacaoSubscription;
+
+  /// Subscription for newly created agenda events.
+  StreamSubscription<Map<String, dynamic>>? _novaPautaSubscription;
+
+  /// Subscription for WebSocket connection status changes.
+  StreamSubscription<String>? _connectionSubscription;
+
+  /// Keeps the screen awake and starts loading dashboard data.
   @override
-  /// Builds the main dashboard layout.
-  ///
-  /// Args:
-  ///   context: The build context used to access inherited widgets and theme
-  ///     data.
-  ///
-  /// Returns:
-  ///   A [Scaffold] containing the header, section toggle, and the currently
-  ///   selected voting content.
+  void initState() {
+    super.initState();
+    WakelockPlus.enable();
+    _loadVereadorData();
+    _loadPautas();
+    _connectWebSocket();
+    _setupWebSocketListeners();
+  }
+
+  /// Connects to the WebSocket service used for real-time notifications.
+  Future<void> _connectWebSocket() async {
+    try {
+      await _webSocketService.connect();
+      print('✅ WebSocket conectado com sucesso no dashboard');
+    } catch (e) {
+      print('❌ Erro ao conectar WebSocket no dashboard: $e');
+    }
+  }
+
+  /// Cancels active subscriptions owned by this dashboard state.
+  @override
+  void dispose() {
+    _pautaStatusSubscription?.cancel();
+    _iniciarVotacaoSubscription?.cancel();
+    _encerrarVotacaoSubscription?.cancel();
+    _novaPautaSubscription?.cancel();
+    _connectionSubscription?.cancel();
+    super.dispose();
+  }
+
+  /// Registers WebSocket listeners for agenda and connection events.
+  void _setupWebSocketListeners() {
+    _pautaStatusSubscription = _webSocketService.pautaStatusUpdates.listen((
+      data,
+    ) async {
+      print('📢 Notificação de mudança de status recebida: $data');
+      await _handlePautaStatusChange(data);
+    });
+
+    _iniciarVotacaoSubscription = _webSocketService.iniciarVotacaoEvents.listen(
+      (data) {
+        print('🗳️ Evento de iniciar votação recebido: $data');
+        _handleIniciarVotacao(data);
+      },
+    );
+
+    _encerrarVotacaoSubscription = _webSocketService.encerrarVotacaoEvents
+        .listen((data) async {
+          print('🏁 Evento de encerrar votação recebido: $data');
+          await _handleEncerrarVotacao(data);
+        });
+
+    _novaPautaSubscription = _webSocketService.novaPautaEvents.listen((
+      data,
+    ) async {
+      print('📝 Evento de nova pauta recebido: $data');
+      await _handleNovaPauta(data);
+    });
+
+    _connectionSubscription = _webSocketService.connectionStatus.listen((
+      status,
+    ) {
+      if (mounted) {
+        setState(() {
+          _connectionStatus = status;
+        });
+      }
+    });
+
+    _connectionStatus = _webSocketService.isConnected
+        ? 'connected'
+        : 'disconnected';
+  }
+
+  /// Applies a received agenda status change to the local cache.
+  Future<void> _handlePautaStatusChange(Map<String, dynamic> data) async {
+    final pautaId = data['pautaId']?.toString();
+    final newStatus = data['newStatus']?.toString();
+
+    if (pautaId == null || newStatus == null) {
+      print('⚠️ Dados incompletos na notificação de status: $data');
+      return;
+    }
+
+    print('🔄 Processando mudança de status: Pauta $pautaId → $newStatus');
+
+    await _applyStatusUpdateToCache(pautaId, newStatus, data);
+  }
+
+  /// Updates the cached agenda status and refreshes derived tab lists.
+  Future<void> _applyStatusUpdateToCache(
+    String pautaId,
+    String newStatus,
+    Map<String, dynamic> statusData,
+  ) async {
+    final normalizedStatus = _normalizeStatus(newStatus);
+
+    if (!_pautasById.containsKey(pautaId)) {
+      final pautaById = await AuthService.getPautaById(pautaId);
+      if (pautaById != null && pautaById.isNotEmpty) {
+        _pautasById[pautaId] = Map<String, dynamic>.from(pautaById);
+      } else {
+        _pautasById[pautaId] = {'id': pautaId};
+      }
+    }
+
+    final pauta = Map<String, dynamic>.from(
+      _pautasById[pautaId] ?? {'id': pautaId},
+    );
+    pauta['id'] = pautaId;
+    pauta['status'] = normalizedStatus;
+
+    if (normalizedStatus.toLowerCase() == 'em votação') {
+      pauta['ao_vivo'] = true;
+    } else if (normalizedStatus.toLowerCase() == 'finalizada') {
+      pauta['ao_vivo'] = false;
+      if (statusData['resultado'] != null) {
+        pauta['resultado_votacao'] = statusData['resultado'];
+      }
+    } else {
+      pauta['ao_vivo'] = false;
+    }
+
+    _pautasById[pautaId] = pauta;
+    _recomputePautasFromCache();
+
+    if (normalizedStatus.toLowerCase() == 'finalizada') {
+      await _loadVotosVereadorForPauta(pautaId);
+    }
+  }
+
+  /// Normalizes backend status values into the labels used by the dashboard.
+  String _normalizeStatus(String status) {
+    final s = status.trim().toLowerCase();
+    if (s == 'em votacao' || s == 'em votação') return 'Em Votação';
+    if (s == 'pendente') return 'Pendente';
+    if (s == 'finalizada') return 'Finalizada';
+    return status;
+  }
+
+  /// Handles a real-time event that marks an agenda vote as finished.
+  Future<void> _handleEncerrarVotacao(Map<String, dynamic> data) async {
+    final pautaId = data['pautaId']?.toString() ?? data['id']?.toString();
+    if (pautaId == null || pautaId.isEmpty) {
+      print('⚠️ Evento de encerrar votação sem pautaId: $data');
+      return;
+    }
+    await _applyStatusUpdateToCache(pautaId, 'Finalizada', data);
+  }
+
+  /// Handles a newly created agenda event and inserts it into the cache.
+  Future<void> _handleNovaPauta(Map<String, dynamic> data) async {
+    final pautaId = data['pautaId']?.toString() ?? data['id']?.toString();
+    if (pautaId == null || pautaId.isEmpty) {
+      print('⚠️ Evento de nova pauta sem pautaId: $data');
+      return;
+    }
+
+    final pautaById = await AuthService.getPautaById(pautaId);
+    if (pautaById != null && pautaById.isNotEmpty) {
+      final pauta = Map<String, dynamic>.from(pautaById);
+      pauta['id'] ??= pautaId;
+      pauta['status'] ??= 'Pendente';
+      pauta['ao_vivo'] ??= false;
+      _pautasById[pautaId] = pauta;
+      _recomputePautasFromCache();
+    } else {
+      _pautasById[pautaId] = {
+        'id': pautaId,
+        'status': 'Pendente',
+        'ao_vivo': false,
+        'nome': data['pautaNome'] ?? 'Nova pauta',
+      };
+      _recomputePautasFromCache();
+    }
+
+    if (mounted) {
+      setState(() {
+        _currentTab = TabState.pendente;
+      });
+    }
+  }
+
+  /// Opens the voting screen when a real-time voting-start event arrives.
+  Future<void> _handleIniciarVotacao(Map<String, dynamic> data) async {
+    final pautaId = data['pautaId']?.toString();
+    final pautaNome = data['pautaNome']?.toString() ?? 'Pauta';
+
+    if (pautaId == null) {
+      print('⚠️ Evento de iniciar votação sem pautaId: $data');
+      return;
+    }
+
+    print(
+      '🗳️ Processando solicitação de iniciar votação: $pautaNome (ID: $pautaId)',
+    );
+
+    final pautaById = await AuthService.getPautaById(pautaId);
+    if (pautaById == null || pautaById.isEmpty) {
+      print('❌ Pauta $pautaId não encontrada via API por ID');
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Aguarde! Carregando votação: $pautaNome'),
+          backgroundColor: const Color(0xFF58a6ff),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    final pauta = Map<String, dynamic>.from(pautaById);
+
+    _upsertPautaFromIniciarVotacao(pautaId, pauta);
+
+    if (!mounted) return;
+
+    bool opened = false;
+    dynamic result;
+    try {
+      opened = true;
+      result = await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => VotacaoPautaScreen(pauta: pauta),
+        ),
+      );
+    } catch (e) {
+      opened = false;
+      print('❌ Falha ao abrir tela de votação automaticamente: $e');
+    }
+
+    if (mounted && !opened) {
+      setState(() {
+        _currentTab = TabState.emVotacao;
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Votação iniciada: $pautaNome'),
+          backgroundColor: const Color(0xFF58a6ff),
+          action: SnackBarAction(
+            label: 'Abrir',
+            textColor: Colors.white,
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => VotacaoPautaScreen(pauta: pauta),
+                ),
+              );
+            },
+          ),
+          duration: const Duration(seconds: 6),
+        ),
+      );
+      return;
+    }
+
+    if (opened) {
+      await _loadVotosVereador();
+      if (result == true) {
+        await _loadPautas();
+      }
+      if (mounted) setState(() {});
+    }
+
+    print('✅ Navegado para tela de votação da pauta: $pautaNome');
+  }
+
+  /// Inserts a just-started agenda into the live voting cache.
+  void _upsertPautaFromIniciarVotacao(
+    String pautaId,
+    Map<String, dynamic> pauta,
+  ) {
+    if (pauta['id'] == null) {
+      pauta['id'] = pautaId;
+    }
+    if ((pauta['status']?.toString().isEmpty ?? true)) {
+      pauta['status'] = 'Em Votação';
+    }
+    if (!pauta.containsKey('ao_vivo')) {
+      pauta['ao_vivo'] = true;
+    }
+
+    _pautasById[pautaId] = Map<String, dynamic>.from(pauta);
+    _recomputePautasFromCache();
+  }
+
+  /// Rebuilds agenda tab lists from the shared agenda cache.
+  void _recomputePautasFromCache() {
+    if (!mounted) return;
+
+    final all = _pautasById.values.toList();
+    all.sort((a, b) {
+      final aCreated = a['created_at']?.toString() ?? '';
+      final bCreated = b['created_at']?.toString() ?? '';
+      return bCreated.compareTo(aCreated);
+    });
+
+    setState(() {
+      _pautasPendentes = all
+          .where((pauta) => pauta['status']?.toLowerCase() == 'pendente')
+          .toList();
+
+      _pautasEmVotacao = all.where((pauta) {
+        final isEmVotacao = pauta['status']?.toLowerCase() == 'em votação';
+        if (!isEmVotacao) return false;
+
+        if (!pauta.containsKey('ao_vivo')) return false;
+        return pauta['ao_vivo'] == true;
+      }).toList();
+
+      _pautasFinalizadas = all
+          .where((pauta) => pauta['status']?.toLowerCase() == 'finalizada')
+          .toList();
+    });
+  }
+
+  /// Loads vote statistics and the council member vote for one agenda item.
+  Future<void> _loadVotosVereadorForPauta(String pautaId) async {
+    try {
+      print('🗳️ Carregando estatísticas da pauta finalizada: $pautaId');
+
+      final estatisticas = await AuthService.getEstatisticasPauta(pautaId);
+      if (estatisticas != null) {
+        final votosResponse = await AuthService.getVotosVereador();
+        if (votosResponse != null) {
+          final votosPorPauta =
+              votosResponse['votosPorPauta'] as Map<String, dynamic>? ?? {};
+          final votoVereador = votosPorPauta[pautaId];
+
+          setState(() {
+            _votosVereador[pautaId] = {
+              'voto': votoVereador?['voto'],
+              'estatisticas': estatisticas['estatisticas'],
+              'resultado': estatisticas['pauta']?['resultado_votacao'],
+            };
+          });
+
+          print('✅ Estatísticas carregadas para pauta $pautaId');
+        }
+      }
+    } catch (e) {
+      print('❌ Erro ao carregar estatísticas da pauta $pautaId: $e');
+    }
+  }
+
+  /// Loads the authenticated council member data displayed in the header.
+  Future<void> _loadVereadorData() async {
+    try {
+      final vereadorData = await AuthService.getVereadorDetails();
+      if (mounted) {
+        setState(() {
+          _vereadorData = vereadorData;
+          _isLoadingVereador = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoadingVereador = false;
+        });
+      }
+    }
+  }
+
+  /// Loads the first agenda page and synchronizes live voting state.
+  Future<void> _loadPautas() async {
+    try {
+      setState(() {
+        _isLoadingPautas = true;
+      });
+
+      print('🔗 Carregando pautas (page=1) via backend tablet...');
+
+      _pautasById.clear();
+      _pautasPage = 1;
+      _pautasTotalPages = 1;
+
+      final response = await AuthService.getPautas(page: 1, limit: 50);
+      if (response == null || response['data'] == null) {
+        print('❌ Erro ao carregar pautas (page=1)');
+        if (mounted) {
+          setState(() {
+            _isLoadingPautas = false;
+          });
+        }
+        return;
+      }
+
+      final pagination = response['pagination'];
+      if (pagination != null) {
+        _pautasTotalPages = pagination['totalPages'] ?? 1;
+      }
+
+      _ingestPautasResponse(response);
+
+      if (_vereadorData != null && _vereadorData!['camara_id'] != null) {
+        final camaraId = _vereadorData!['camara_id'].toString();
+        final liveStatus = await AuthService.getLiveVotingStatus(camaraId);
+        final Set<String> activeIds = {};
+
+        if (liveStatus != null &&
+            liveStatus['isLive'] == true &&
+            liveStatus['votacoes'] != null) {
+          final votacoes = liveStatus['votacoes'] as List;
+          for (final v in votacoes) {
+            final activeId = v['pautaId']?.toString();
+            if (activeId != null) activeIds.add(activeId);
+          }
+        }
+
+        for (final pauta in _pautasById.values) {
+          if (pauta['status'] == 'Em Votação') {
+            final id = pauta['id']?.toString();
+            final shouldBeLive = activeIds.contains(id);
+
+            if (pauta['ao_vivo'] != shouldBeLive) {
+              print('🧹 Sanitizando pauta $id: ao_vivo = $shouldBeLive');
+              pauta['ao_vivo'] = shouldBeLive;
+            }
+          }
+        }
+        _recomputePautasFromCache();
+      }
+
+      if (mounted) {
+        setState(() {
+          _isLoadingPautas = false;
+        });
+
+        print('✅ Pautas organizadas (page=1):');
+        print('   - Pendentes: ${_pautasPendentes.length}');
+        print('   - Em Votação: ${_pautasEmVotacao.length}');
+        print('   - Finalizadas: ${_pautasFinalizadas.length}');
+        print(
+          '   - Pagination: page=$_pautasPage / totalPages=$_pautasTotalPages',
+        );
+
+        await _loadVotosVereador();
+      }
+    } catch (e) {
+      print('💥 Erro ao carregar pautas: $e');
+      if (mounted) {
+        setState(() {
+          _isLoadingPautas = false;
+        });
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Erro ao carregar pautas: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  /// Adds one backend agenda response page to the local agenda cache.
+  void _ingestPautasResponse(Map<String, dynamic> response) {
+    final pautasData = response['data'];
+    if (pautasData == null) return;
+
+    final List<Map<String, dynamic>> pageItems = [];
+    if (pautasData['pendentes'] != null) {
+      pageItems.addAll(
+        List<Map<String, dynamic>>.from(pautasData['pendentes']),
+      );
+    }
+    if (pautasData['emVotacao'] != null) {
+      pageItems.addAll(
+        List<Map<String, dynamic>>.from(pautasData['emVotacao']),
+      );
+    }
+    if (pautasData['finalizadas'] != null) {
+      pageItems.addAll(
+        List<Map<String, dynamic>>.from(pautasData['finalizadas']),
+      );
+    }
+
+    for (final pauta in pageItems) {
+      final id = pauta['id']?.toString();
+      if (id == null || id.isEmpty) continue;
+      _pautasById[id] = Map<String, dynamic>.from(pauta);
+    }
+
+    _recomputePautasFromCache();
+  }
+
+  /// Loads the next agenda page when pagination has more data.
+  Future<void> _loadMorePautas() async {
+    if (_isLoadingPautas || _isLoadingMorePautas) return;
+    if (_pautasPage >= _pautasTotalPages) return;
+
+    try {
+      if (mounted) {
+        setState(() {
+          _isLoadingMorePautas = true;
+        });
+      }
+
+      final nextPage = _pautasPage + 1;
+      print('📡 Carregando mais pautas (page=$nextPage)...');
+
+      final response = await AuthService.getPautas(page: nextPage, limit: 50);
+      if (response == null || response['data'] == null) {
+        print('❌ Erro ao carregar pautas da página $nextPage');
+        return;
+      }
+
+      _pautasPage = nextPage;
+      final pagination = response['pagination'];
+      if (pagination != null) {
+        _pautasTotalPages = pagination['totalPages'] ?? _pautasTotalPages;
+      }
+
+      _ingestPautasResponse(response);
+    } catch (e) {
+      print('💥 Erro ao carregar mais pautas: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingMorePautas = false;
+        });
+      }
+    }
+  }
+
+  /// Triggers pagination when the current list is scrolled near the end.
+  bool _onScrollNotification(ScrollNotification notification) {
+    if (notification.metrics.extentAfter < 300) {
+      _loadMorePautas();
+    }
+    return false;
+  }
+
+  /// Loads the current council member votes and finished-agenda statistics.
+  Future<void> _loadVotosVereador() async {
+    try {
+      print('🗳️ Carregando votos do vereador via backend tablet...');
+
+      final votosResponse = await AuthService.getVotosVereador();
+
+      if (votosResponse != null) {
+        final votosPorPauta =
+            votosResponse['votosPorPauta'] as Map<String, dynamic>? ?? {};
+
+        final pautasFinalizadasIds = _pautasFinalizadas
+            .map((p) => p['id'])
+            .where((id) => id != null)
+            .toList();
+
+        for (final pautaId in pautasFinalizadasIds) {
+          try {
+            final estatisticas = await AuthService.getEstatisticasPauta(
+              pautaId,
+            );
+            if (estatisticas != null) {
+              final votoVereador = votosPorPauta[pautaId];
+
+              setState(() {
+                _votosVereador[pautaId] = {
+                  'voto': votoVereador?['voto'],
+                  'estatisticas': estatisticas['estatisticas'],
+                  'resultado': estatisticas['pauta']?['resultado_votacao'],
+                };
+              });
+            }
+          } catch (e) {
+            print('Erro ao carregar estatísticas da pauta $pautaId: $e');
+          }
+        }
+
+        final pautasEmVotacaoIds = _pautasEmVotacao
+            .map((p) => p['id'])
+            .where((id) => id != null)
+            .toList();
+        for (final pautaId in pautasEmVotacaoIds) {
+          final votoVereador = votosPorPauta[pautaId];
+          if (votoVereador != null) {
+            setState(() {
+              _votosVereador[pautaId] = {'voto': votoVereador['voto']};
+            });
+          }
+        }
+
+        print(
+          '✅ Votos do vereador carregados: ${_votosVereador.length} pautas com voto',
+        );
+      }
+    } catch (e) {
+      print('💥 Erro ao carregar votos do vereador: $e');
+    }
+  }
+
+  /// Opens an agenda PDF in an external application when an attachment exists.
+  Future<void> _openPautaPDF(String? anexoUrl) async {
+    if (anexoUrl == null || anexoUrl.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Esta pauta não possui arquivo PDF anexado'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    try {
+      String finalUrl = anexoUrl;
+      if (!anexoUrl.startsWith('http')) {
+        if (anexoUrl.startsWith('/')) {
+          finalUrl = anexoUrl.substring(1);
+        }
+        finalUrl = 'https://legislanet.com.br/$finalUrl';
+      }
+
+      print('📄 Abrindo PDF: $finalUrl');
+      final uri = Uri.parse(finalUrl);
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } else {
+        throw 'Não foi possível abrir o PDF';
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Erro ao abrir PDF: $e'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  /// Handles agenda selection based on the agenda status.
+  void _handlePautaTap(Map<String, dynamic> pauta, String status) async {
+    if (status.toLowerCase() == 'pendente') {
+      _openPautaPDF(pauta['anexo_url']);
+    } else if (status.toLowerCase() == 'em votação') {
+      final result = await Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => VotacaoPautaScreen(pauta: pauta),
+        ),
+      );
+
+      if (result is Map &&
+          result['votoRegistrado'] == true &&
+          result['voto'] != null) {
+        print('✅ UI Otimista: Aplicando voto ${result['voto']} imediatamente.');
+        _votosVereador[pauta['id'].toString()] = {
+          'voto': result['voto'],
+          'pauta_id': pauta['id'],
+          'created_at': DateTime.now().toIso8601String(),
+        };
+        if (mounted) setState(() {});
+      }
+
+      await _loadVotosVereador();
+
+      if (result == true ||
+          (result is Map && result['votoRegistrado'] == true)) {
+        await _loadPautas();
+      }
+
+      if (mounted) setState(() {});
+    }
+  }
+
+  /// Returns the current council member vote state for an agenda item.
+  VotoTipo _getVotoFromData(String? pautaId) {
+    if (pautaId == null) return VotoTipo.naoVotado;
+
+    final votoData = _votosVereador[pautaId];
+    if (votoData == null) return VotoTipo.naoVotado;
+
+    switch (votoData['voto']) {
+      case 'SIM':
+        return VotoTipo.sim;
+      case 'NÃO':
+        return VotoTipo.nao;
+      case 'ABSTENÇÃO':
+        return VotoTipo.abstencao;
+      default:
+        return VotoTipo.naoVotado;
+    }
+  }
+
+  /// Returns the display status for a finished agenda result.
+  String _getStatusFromResult(Map<String, dynamic> pauta) {
+    final resultado = pauta['resultado_votacao'];
+    if (resultado == null) return 'Finalizada';
+
+    switch (resultado) {
+      case 'Aprovada':
+        return 'Aprovada';
+      case 'Reprovada':
+        return 'Reprovada';
+      default:
+        return 'Finalizada';
+    }
+  }
+
+  /// Returns the color associated with a finished agenda result.
+  Color _getStatusColor(Map<String, dynamic> pauta) {
+    final resultado = pauta['resultado_votacao'];
+
+    switch (resultado) {
+      case 'Aprovada':
+        return const Color(0xFF2EA043);
+      case 'Reprovada':
+        return const Color(0xFFDA3633);
+      case 'Abstenção':
+      case 'Empate':
+        return const Color(0xFFF08833);
+      default:
+        return const Color(0xFF6e7681);
+    }
+  }
+
+  /// Returns the connection indicator color for the current status.
+  Color _getConnectionColor() {
+    switch (_connectionStatus) {
+      case 'connected':
+        return const Color(0xFF2EA043);
+      case 'reconnecting':
+        return const Color(0xFFF08833);
+      case 'disconnected':
+      default:
+        return const Color(0xFFDA3633);
+    }
+  }
+
+  /// Returns the connection indicator icon for the current status.
+  IconData _getConnectionIcon() {
+    switch (_connectionStatus) {
+      case 'connected':
+        return Icons.flash_on;
+      case 'reconnecting':
+        return Icons.sync;
+      case 'disconnected':
+      default:
+        return Icons.wifi_off;
+    }
+  }
+
+  /// Returns the connection indicator text for the current status.
+  String _getConnectionText() {
+    switch (_connectionStatus) {
+      case 'connected':
+        return 'Conectado';
+      case 'reconnecting':
+        return 'Reconectando...';
+      case 'disconnected':
+      default:
+        return 'Desconectado';
+    }
+  }
+
+  /// Logs out the current user and returns to the initial route.
+  Future<void> _handleLogout() async {
+    await AuthService.logout();
+    if (mounted) {
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+    }
+  }
+
+  /// Builds the dashboard shell with header, tabs, and the selected agenda view.
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: SafeArea(
-        child: Column(
+      body: Container(
+        decoration: const BoxDecoration(
+          color: Color(0xFF0d1117),
+          gradient: LinearGradient(
+            begin: Alignment(-0.7071, -0.7071),
+            end: Alignment(0.7071, 0.7071),
+            colors: [
+              Color.fromRGBO(88, 166, 255, 0.08),
+              Color.fromRGBO(46, 160, 67, 0.06),
+              Color.fromRGBO(138, 58, 185, 0.05),
+              Color.fromRGBO(240, 136, 51, 0.07),
+              Color.fromRGBO(88, 166, 255, 0.04),
+            ],
+            stops: [0.0, 0.25, 0.5, 0.75, 1.0],
+          ),
+        ),
+        child: Stack(
           children: [
-            _buildHeader(),
-            const SizedBox(height: 24),
-            _buildToggleButtons(),
-            const SizedBox(height: 24),
-            if (_showFinalizadas)
-              _buildFinalizadasView()
-            else
-              _buildEmAndamentoView(),
+            Positioned(
+              left: MediaQuery.of(context).size.width * 0.2 - 200,
+              top: MediaQuery.of(context).size.height * 0.3 - 200,
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    center: Alignment.center,
+                    radius: 0.6,
+                    colors: [
+                      const Color.fromRGBO(46, 160, 67, 0.05),
+                      Colors.transparent,
+                    ],
+                    stops: const [0.0, 0.6],
+                  ),
+                ),
+              ),
+            ),
+            Positioned(
+              left: MediaQuery.of(context).size.width * 0.8 - 200,
+              top: MediaQuery.of(context).size.height * 0.7 - 200,
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    center: Alignment.center,
+                    radius: 0.6,
+                    colors: [
+                      const Color.fromRGBO(138, 58, 185, 0.04),
+                      Colors.transparent,
+                    ],
+                    stops: const [0.0, 0.6],
+                  ),
+                ),
+              ),
+            ),
+            SafeArea(
+              child: Column(
+                children: [
+                  _buildHeader(),
+                  const SizedBox(height: 24),
+                  _buildTabButtons(),
+                  const SizedBox(height: 24),
+                  _buildCurrentView(),
+                ],
+              ),
+            ),
           ],
         ),
       ),
     );
   }
 
-  /// Builds the greeting header displayed at the top of the dashboard.
-  ///
-  /// Returns:
-  ///   A styled [Container] with the council member avatar, greeting text, and
-  ///   an exit action button.
+  /// Builds the dashboard header with profile, connection status, and logout.
   Widget _buildHeader() {
     return Container(
       padding: const EdgeInsets.all(16.0),
       margin: const EdgeInsets.symmetric(horizontal: 16.0),
       decoration: BoxDecoration(
-        color: Theme.of(context).cardTheme.color, // Cor do card vinda do tema
+        color: Theme.of(context).cardTheme.color,
         borderRadius: BorderRadius.circular(12),
       ),
       child: Row(
         children: [
-          const CircleAvatar(
-            radius: 35, // Tamanho ajustado
-            backgroundImage: NetworkImage('https://i.imgur.com/5h25c3G.png'),
-          ), //
+          CircleAvatar(
+            radius: 35,
+            backgroundColor: Colors.grey[600],
+            child: _isLoadingVereador
+                ? const CircularProgressIndicator(
+                    color: Colors.white,
+                    strokeWidth: 2,
+                  )
+                : _vereadorData?['foto_url'] != null &&
+                      _vereadorData!['foto_url'].isNotEmpty
+                ? ClipOval(
+                    child: Image.network(
+                      _vereadorData!['foto_url'],
+                      width: 70,
+                      height: 70,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) {
+                        return const Icon(
+                          Icons.person,
+                          size: 40,
+                          color: Colors.white,
+                        );
+                      },
+                    ),
+                  )
+                : const Icon(Icons.person, size: 40, color: Colors.white),
+          ),
           const SizedBox(width: 16),
           Expanded(
             child: Column(
@@ -94,72 +974,89 @@ class _DashboardVereadorScreenState extends State<DashboardVereadorScreen> {
                   'Boa tarde Vereador,',
                   style: TextStyle(fontSize: 16, color: Colors.white70),
                 ),
-                const Text(
-                  'DE ASSIS DANTAS',
-                  style: TextStyle(
+                Text(
+                  _vereadorData?['nome_parlamentar'] ??
+                      AuthService.currentUser?['nome'] ??
+                      'Carregando...',
+                  style: const TextStyle(
                     fontSize: 22,
                     fontWeight: FontWeight.bold,
                     color: Colors.white,
                   ),
-                ), //
+                ),
                 const SizedBox(height: 4),
-                const Text(
-                  'Câmara municipal de Dom Expedito Lopes, 08 de agosto de 2025',
-                  style: TextStyle(fontSize: 12, color: Colors.white60),
-                ), //
+                Text(
+                  'Câmara municipal, ${DateTime.now().day}/${DateTime.now().month}/${DateTime.now().year}',
+                  style: const TextStyle(fontSize: 12, color: Colors.white60),
+                ),
+              ],
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            margin: const EdgeInsets.only(right: 12),
+            decoration: BoxDecoration(
+              color: _getConnectionColor(),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(_getConnectionIcon(), color: Colors.white, size: 16),
+                const SizedBox(width: 6),
+                Text(
+                  _getConnectionText(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
               ],
             ),
           ),
           IconButton(
-            onPressed: () {},
-            icon: const Icon(Icons.exit_to_app, color: Color(0xFFF08833)), //
+            onPressed: _handleLogout,
+            icon: const Icon(Icons.exit_to_app, color: Color(0xFFF08833)),
           ),
         ],
       ),
     );
   }
 
-  /// Builds the segmented toggle used to switch dashboard sections.
-  ///
-  /// Returns:
-  ///   A [Container] with buttons for the ongoing and completed voting views.
-  Widget _buildToggleButtons() {
+  /// Builds the tab selector for pending, live, and finished agendas.
+  Widget _buildTabButtons() {
     return Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).cardTheme.color, // Cor do tema
+        color: const Color.fromRGBO(22, 27, 34, 0.85),
         borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFF30363d)),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _buildToggleButton('Em Andamento', !_showFinalizadas), //
-          _buildToggleButton('Finalizada', _showFinalizadas), //
+          _buildTabButton('Pendente', TabState.pendente),
+          _buildTabButton('Em Votação', TabState.emVotacao),
+          _buildTabButton('Finalizada', TabState.finalizada),
         ],
       ),
     );
   }
 
-  /// Builds an individual toggle button for the dashboard section selector.
-  ///
-  /// Args:
-  ///   text: The label shown inside the toggle button.
-  ///   isSelected: Whether this button represents the currently active section.
-  ///
-  /// Returns:
-  ///   A tappable widget that updates the selected dashboard section when
-  ///   pressed.
-  Widget _buildToggleButton(String text, bool isSelected) {
+  /// Builds one selectable tab button.
+  Widget _buildTabButton(String text, TabState tabState) {
+    final isSelected = _currentTab == tabState;
     return GestureDetector(
       onTap: () {
         setState(() {
-          _showFinalizadas = text == 'Finalizada';
+          _currentTab = tabState;
         });
       },
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(horizontal: 48, vertical: 12),
+        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 12),
         decoration: BoxDecoration(
-          color: isSelected ? const Color(0xFF2F81F7) : Colors.transparent, //
+          color: isSelected ? const Color(0xFF58a6ff) : Colors.transparent,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Text(
@@ -167,50 +1064,193 @@ class _DashboardVereadorScreenState extends State<DashboardVereadorScreen> {
           style: TextStyle(
             color: Colors.white,
             fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            fontSize: 14,
           ),
         ),
       ),
     );
   }
 
-  // Adicionado card "Não votado" com navegação
-  /// Builds the content for the ongoing votes section.
-  ///
-  /// Returns:
-  ///   A padded layout containing the current active voting card and navigation
-  ///   to the voting details screen.
-  Widget _buildEmAndamentoView() {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-      child: Column(
-        children: [
-          // Card para pauta não votada
-          GestureDetector(
-            onTap: () {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => const VotacaoPautaScreen(),
+  /// Builds the agenda list that matches the currently selected tab.
+  Widget _buildCurrentView() {
+    switch (_currentTab) {
+      case TabState.pendente:
+        return _buildPendenteView();
+      case TabState.emVotacao:
+        return _buildEmVotacaoView();
+      case TabState.finalizada:
+        return _buildFinalizadasView();
+    }
+  }
+
+  /// Builds the pending agenda view, including pagination loading state.
+  Widget _buildPendenteView() {
+    if (_isLoadingPautas) {
+      return const Center(
+        child: CircularProgressIndicator(color: Color(0xFF58a6ff)),
+      );
+    }
+
+    if (_pautasPendentes.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Icon(Icons.check_circle_outline, size: 64, color: Colors.grey),
+              SizedBox(height: 16),
+              Text(
+                'Nenhuma pauta pendente',
+                style: TextStyle(fontSize: 18, color: Colors.grey),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final hasMore = _pautasPage < _pautasTotalPages;
+    final extraItem = (hasMore || _isLoadingMorePautas) ? 1 : 0;
+
+    return Expanded(
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _onScrollNotification,
+        child: ListView.builder(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          itemCount: _pautasPendentes.length + extraItem,
+          itemBuilder: (context, index) {
+            if (index >= _pautasPendentes.length) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: Center(
+                  child: _isLoadingMorePautas
+                      ? const CircularProgressIndicator(
+                          color: Color(0xFF58a6ff),
+                        )
+                      : const SizedBox.shrink(),
                 ),
               );
-            },
-            child: const _VotacaoCard(
-              tema: 'Projeto de Lei 101/2025 - 1ª votação',
-              meuVoto: VotoTipo.naoVotado,
-              status: 'Em Andamento',
-              statusColor: Color(0xFF2EA043),
-            ),
-          ),
-        ],
+            }
+
+            final pauta = _pautasPendentes[index];
+            return GestureDetector(
+              onTap: () => _handlePautaTap(pauta, 'Pendente'),
+              child: _VotacaoCard(
+                tema: pauta['nome'] ?? 'Pauta sem nome',
+                meuVoto: VotoTipo.naoVotado,
+                status: 'Pendente',
+                statusColor: const Color(0xFFF0E333),
+                description: pauta['descricao'] ?? '',
+                autor: pauta['autor'] ?? 'Não informado',
+                showVoto: false,
+              ),
+            );
+          },
+        ),
       ),
     );
   }
 
-  /// Builds the content for the completed votes section.
-  ///
-  /// Returns:
-  ///   An [Expanded] widget containing a scrollable list of finalized voting
-  ///   cards.
+  /// Builds the live voting agenda view.
+  Widget _buildEmVotacaoView() {
+    if (_isLoadingPautas) {
+      return const Center(
+        child: CircularProgressIndicator(color: Color(0xFF58a6ff)),
+      );
+    }
+
+    if (_pautasEmVotacao.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Icon(Icons.how_to_vote_outlined, size: 64, color: Colors.grey),
+              SizedBox(height: 16),
+              Text(
+                'Nenhuma pauta em votação',
+                style: TextStyle(fontSize: 18, color: Colors.grey),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final hasMore = _pautasPage < _pautasTotalPages;
+    final extraItem = (hasMore || _isLoadingMorePautas) ? 1 : 0;
+
+    return Expanded(
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _onScrollNotification,
+        child: ListView.builder(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          itemCount: _pautasEmVotacao.length + extraItem,
+          itemBuilder: (context, index) {
+            if (index >= _pautasEmVotacao.length) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                child: Center(
+                  child: _isLoadingMorePautas
+                      ? const CircularProgressIndicator(
+                          color: Color(0xFF58a6ff),
+                        )
+                      : const SizedBox.shrink(),
+                ),
+              );
+            }
+
+            final pauta = _pautasEmVotacao[index];
+            return GestureDetector(
+              onTap: () => _handlePautaTap(pauta, 'Em Votação'),
+              child: _VotacaoCard(
+                tema: pauta['nome'] ?? 'Pauta sem nome',
+                meuVoto: _getVotoFromData(pauta['id']),
+                status: 'Em Votação',
+                statusColor: const Color(0xFF58a6ff),
+                description: pauta['descricao'] ?? '',
+                autor: pauta['autor'] ?? 'Não informado',
+                showVoto: true,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  /// Builds the finished agenda view with results and vote statistics.
   Widget _buildFinalizadasView() {
+    if (_isLoadingPautas) {
+      return const Center(
+        child: CircularProgressIndicator(color: Color(0xFF58a6ff)),
+      );
+    }
+
+    if (_pautasFinalizadas.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Icon(Icons.task_alt_outlined, size: 64, color: Colors.grey),
+              SizedBox(height: 16),
+              Text(
+                'Nenhuma pauta finalizada',
+                style: TextStyle(fontSize: 18, color: Colors.grey),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final hasMore = _pautasPage < _pautasTotalPages;
+    final extraItem = (hasMore || _isLoadingMorePautas) ? 1 : 0;
+
     return Expanded(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -224,42 +1264,43 @@ class _DashboardVereadorScreenState extends State<DashboardVereadorScreen> {
                 style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: Colors.white,
+                  color: Color(0xFFe6edf3),
                 ),
-              ), //
+              ),
             ),
             Expanded(
-              child: ListView(
-                children: const [
-                  _VotacaoCard(
-                    tema: 'Denúncia - 2ª votação', //
-                    meuVoto: VotoTipo.sim,
-                    status:
-                        'Aprovado - 6 votos Sim - 0 votos Não - 0 abstenções', //
-                    statusColor: Color(0xFF2EA043),
-                  ),
-                  _VotacaoCard(
-                    tema: 'Denúncia - 1ª votação', //
-                    meuVoto: VotoTipo.nao,
-                    status:
-                        'Aprovado - 7 votos Sim - 0 votos Não - 0 abstenções', //
-                    statusColor: Color(0xFF2EA043),
-                  ),
-                  _VotacaoCard(
-                    tema: 'PROJETO DE LEI 030/2025 - 2ª votação', //
-                    meuVoto: VotoTipo.naoVotado,
-                    status:
-                        'Reprovado - 0 votos Sim - 0 votos Não - 0 abstenções', //
-                    statusColor: Color(0xFFDA3633),
-                  ),
-                  _VotacaoCard(
-                    tema: 'PROJETO DE LEI 030/2025 - 1ª votação',
-                    meuVoto: VotoTipo.abstencao,
-                    status:
-                        'Aprovado - 9 votos Sim - 0 votos Não - 0 abstenções',
-                    statusColor: Color(0xFF2EA043),
-                  ),
-                ],
+              child: NotificationListener<ScrollNotification>(
+                onNotification: _onScrollNotification,
+                child: ListView.builder(
+                  itemCount: _pautasFinalizadas.length + extraItem,
+                  itemBuilder: (context, index) {
+                    if (index >= _pautasFinalizadas.length) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 16.0),
+                        child: Center(
+                          child: _isLoadingMorePautas
+                              ? const CircularProgressIndicator(
+                                  color: Color(0xFF58a6ff),
+                                )
+                              : const SizedBox.shrink(),
+                        ),
+                      );
+                    }
+
+                    final pauta = _pautasFinalizadas[index];
+                    return _VotacaoCard(
+                      tema: pauta['nome'] ?? 'Pauta sem nome',
+                      meuVoto: _getVotoFromData(pauta['id']),
+                      status: _getStatusFromResult(pauta),
+                      statusColor: _getStatusColor(pauta),
+                      description: pauta['descricao'] ?? '',
+                      autor: pauta['autor'] ?? 'Não informado',
+                      showVoto: true,
+                      estatisticas:
+                          _votosVereador[pauta['id']]?['estatisticas'],
+                    );
+                  },
+                ),
               ),
             ),
           ],
@@ -269,57 +1310,60 @@ class _DashboardVereadorScreenState extends State<DashboardVereadorScreen> {
   }
 }
 
-/// Displays a summary card for a voting item.
-///
-/// The card presents the topic, the current user's vote, and a status summary
-/// with the appropriate highlight color.
+/// Card that displays agenda metadata, status, vote, and optional statistics.
 class _VotacaoCard extends StatelessWidget {
+  /// Agenda title.
   final String tema;
+
+  /// Current council member vote for this agenda.
   final VotoTipo meuVoto;
+
+  /// Display status for this agenda.
   final String status;
+
+  /// Color used by the primary status badge.
   final Color statusColor;
 
-  /// Creates a voting summary card.
-  ///
-  /// Args:
-  ///   tema: The voting topic shown as the main title of the card.
-  ///   meuVoto: The current user's vote type used to determine the badge text
-  ///     and color.
-  ///   status: The voting result or current state text displayed on the card.
-  ///   statusColor: The color used to render the status text.
+  /// Optional agenda description.
+  final String? description;
+
+  /// Optional agenda author name.
+  final String? autor;
+
+  /// Whether the current council member vote should be shown.
+  final bool showVoto;
+
+  /// Optional final vote statistics shown for completed agendas.
+  final Map<String, dynamic>? estatisticas;
+
+  /// Creates an agenda card.
   const _VotacaoCard({
     required this.tema,
     required this.meuVoto,
     required this.status,
     required this.statusColor,
+    this.description,
+    this.autor,
+    this.showVoto = true,
+    this.estatisticas,
   });
 
-  /// Returns the label and color associated with the current vote type.
-  ///
-  /// Returns:
-  ///   A map containing the formatted vote `text` and its display `color`.
+  /// Returns the text and color used to display [meuVoto].
   Map<String, dynamic> _getVotoStyle() {
     switch (meuVoto) {
       case VotoTipo.sim:
-        return {'text': 'sim', 'color': const Color(0xFF2EA043)}; //
+        return {'text': 'sim', 'color': const Color(0xFF2EA043)};
       case VotoTipo.nao:
         return {'text': 'não', 'color': const Color(0xFFDA3633)};
       case VotoTipo.abstencao:
         return {'text': 'abstenção', 'color': const Color(0xFFF08833)};
       case VotoTipo.naoVotado:
-        return {'text': 'Não votado', 'color': Colors.grey[700]!}; //
+        return {'text': 'Não votado', 'color': Colors.grey[700]!};
     }
   }
 
+  /// Builds the agenda card UI.
   @override
-  /// Builds the visual representation of the voting card.
-  ///
-  /// Args:
-  ///   context: The build context used to resolve inherited theme information.
-  ///
-  /// Returns:
-  ///   A [Card] widget containing the topic, vote badge, and status
-  ///   information.
   Widget build(BuildContext context) {
     final votoStyle = _getVotoStyle();
     return Card(
@@ -329,55 +1373,229 @@ class _VotacaoCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              'Tema: $tema',
-              style: const TextStyle(
-                fontSize: 16,
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 12),
             Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Row(
-                  children: [
-                    const Text(
-                      'Meu voto: ',
-                      style: TextStyle(fontSize: 14, color: Colors.white70),
+                Expanded(
+                  child: Text(
+                    tema,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
                     ),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 10,
-                        vertical: 4,
+                  ),
+                ),
+                if (status.toLowerCase() == 'aprovada' ||
+                    status.toLowerCase() == 'reprovada') ...[
+                  _buildBasicStatusBadge('FINALIZADA'),
+                  const SizedBox(width: 8),
+                  _buildStatusBadge(),
+                ] else
+                  _buildStatusBadge(),
+              ],
+            ),
+            if (description?.isNotEmpty == true) ...[
+              const SizedBox(height: 8),
+              Text(
+                description!,
+                style: const TextStyle(fontSize: 14, color: Colors.white70),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            if (autor?.isNotEmpty == true) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Autor: $autor',
+                style: const TextStyle(fontSize: 12, color: Colors.white60),
+              ),
+            ],
+            if (showVoto) ...[
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Text(
+                    'Meu voto: ',
+                    style: TextStyle(fontSize: 14, color: Colors.white70),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: votoStyle['color'],
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    child: Text(
+                      votoStyle['text'],
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
                       ),
-                      decoration: BoxDecoration(
-                        color: votoStyle['color'],
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Text(
-                        votoStyle['text'],
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+            if (estatisticas != null &&
+                (status == 'Aprovada' || status == 'Reprovada')) ...[
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.white.withValues(alpha: 0.05),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: Colors.white.withValues(alpha: 0.1),
+                  ),
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceAround,
+                  children: [
+                    _buildVoteCount(
+                      'SIM',
+                      estatisticas!['sim'] ?? 0,
+                      const Color(0xFF2EA043),
+                    ),
+                    _buildVoteCount(
+                      'NÃO',
+                      estatisticas!['nao'] ?? 0,
+                      const Color(0xFFDA3633),
+                    ),
+                    _buildVoteCount(
+                      'ABSTENÇÃO',
+                      estatisticas!['abstencao'] ?? 0,
+                      const Color(0xFFF08833),
                     ),
                   ],
                 ),
-                Text(
-                  status,
-                  style: TextStyle(
-                    color: statusColor,
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds a compact vote count item for completed agenda statistics.
+  Widget _buildVoteCount(String label, int count, Color color) {
+    return Column(
+      children: [
+        Text(
+          count.toString(),
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
+        ),
+        Text(
+          label,
+          style: const TextStyle(fontSize: 12, color: Colors.white60),
+        ),
+      ],
+    );
+  }
+
+  /// Builds a neutral status badge used alongside final result badges.
+  Widget _buildBasicStatusBadge(String badgeStatus) {
+    Color backgroundColor;
+    Color textColor;
+    Color borderColor;
+
+    switch (badgeStatus.toLowerCase()) {
+      case 'finalizada':
+        backgroundColor = const Color.fromRGBO(46, 160, 67, 0.2);
+        textColor = const Color(0xFF71e67f);
+        borderColor = const Color.fromRGBO(46, 160, 67, 0.4);
+        break;
+      default:
+        backgroundColor = const Color.fromRGBO(240, 227, 51, 0.2);
+        textColor = const Color.fromRGBO(233, 241, 110, 1);
+        borderColor = const Color.fromRGBO(240, 227, 51, 0.4);
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(99),
+        border: Border.all(color: borderColor),
+      ),
+      child: Text(
+        badgeStatus.toUpperCase(),
+        style: TextStyle(
+          color: textColor,
+          fontSize: 10,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+
+  /// Builds the agenda status badge with status-specific colors.
+  Widget _buildStatusBadge() {
+    if (status.toLowerCase() == 'aprovada' ||
+        status.toLowerCase() == 'reprovada') {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        decoration: BoxDecoration(
+          color: statusColor.withValues(alpha: 0.2),
+          borderRadius: BorderRadius.circular(99),
+          border: Border.all(color: statusColor.withValues(alpha: 0.6)),
+        ),
+        child: Text(
+          status.toUpperCase(),
+          style: TextStyle(
+            color: statusColor,
+            fontSize: 10,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      );
+    }
+
+    Color backgroundColor;
+    Color textColor;
+    Color borderColor;
+
+    switch (status.toLowerCase()) {
+      case 'pendente':
+        backgroundColor = const Color.fromRGBO(240, 227, 51, 0.2);
+        textColor = const Color.fromRGBO(233, 241, 110, 1);
+        borderColor = const Color.fromRGBO(240, 227, 51, 0.4);
+        break;
+      case 'em votação':
+        backgroundColor = const Color.fromRGBO(88, 166, 255, 0.2);
+        textColor = Colors.cyan;
+        borderColor = const Color.fromRGBO(88, 166, 255, 0.4);
+        break;
+      case 'finalizada':
+        backgroundColor = const Color.fromRGBO(46, 160, 67, 0.2);
+        textColor = const Color(0xFF71e67f);
+        borderColor = const Color.fromRGBO(46, 160, 67, 0.4);
+        break;
+      default:
+        backgroundColor = const Color.fromRGBO(240, 227, 51, 0.2);
+        textColor = const Color.fromRGBO(233, 241, 110, 1);
+        borderColor = const Color.fromRGBO(240, 227, 51, 0.4);
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(99),
+        border: Border.all(color: borderColor),
+      ),
+      child: Text(
+        status.toUpperCase(),
+        style: TextStyle(
+          color: textColor,
+          fontSize: 10,
+          fontWeight: FontWeight.w500,
         ),
       ),
     );

--- a/tablet_app/lib/votacao_pauta_screen.dart
+++ b/tablet_app/lib/votacao_pauta_screen.dart
@@ -1,157 +1,598 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
+import 'services/auth_service.dart';
+import 'services/websocket_service.dart';
 
-// Enum para controlar qual opção de voto está selecionada
-/// Defines the available voting choices for the agenda voting screen.
-///
-/// This enum is used to track which vote option the user has currently
-/// selected, including the state where no option has been chosen yet.
+/// Available vote choices for a voting agenda item.
 enum VotoOpcao { sim, nao, abstencao, nenhum }
 
-/// Displays the voting details screen for a specific agenda item.
-///
-/// This screen presents agenda information, an attachment preview action, and
-/// selectable vote options for the user to confirm.
+/// Screen that lets a council member vote on an active agenda item.
 class VotacaoPautaScreen extends StatefulWidget {
-  /// Creates the agenda voting screen.
-  ///
-  /// Args:
-  ///   key: The widget key used to preserve this widget's identity in the
-  ///     widget tree.
-  const VotacaoPautaScreen({super.key});
+  /// Agenda metadata used to display details and identify the voting room.
+  final Map<String, dynamic> pauta;
+
+  /// Creates the voting screen for the provided [pauta].
+  const VotacaoPautaScreen({super.key, required this.pauta});
 
   @override
-  /// Creates the mutable state for [VotacaoPautaScreen].
-  ///
-  /// Returns:
-  ///   A [_VotacaoPautaScreenState] instance that manages the selected vote.
   State<VotacaoPautaScreen> createState() => _VotacaoPautaScreenState();
 }
 
-/// Holds the interactive state for [VotacaoPautaScreen].
-///
-/// This state object stores the currently selected vote option and builds the
-/// interface for viewing agenda details and casting a vote.
+/// Manages vote selection, submission, statistics, and real-time updates.
 class _VotacaoPautaScreenState extends State<VotacaoPautaScreen> {
-  // Variável de estado para guardar a opção de voto escolhida
+  /// Currently selected vote option.
   VotoOpcao _votoSelecionado = VotoOpcao.nenhum;
 
+  /// Current WebSocket connection state used by the connection indicator.
+  String _connectionStatus = 'connected';
+
+  /// Tracks whether a vote submission is currently in progress.
+  bool _isVoting = false;
+
+  /// Indicates whether this screen has successfully registered a vote.
+  bool _votoFoiRegistrado = false;
+
+  /// Latest vote statistics for the current agenda item.
+  Map<String, dynamic>? _estatisticas;
+
+  /// Tracks whether vote statistics are currently being loaded.
+  bool _isLoadingStats = false;
+
+  /// Shared WebSocket service used for live voting updates.
+  final WebSocketService _webSocketService = WebSocketService.instance;
+
+  /// Subscription for vote notification events.
+  StreamSubscription<Map<String, dynamic>>? _votoNotificationSubscription;
+
+  /// Subscription for live statistics update events.
+  StreamSubscription<Map<String, dynamic>>? _statsUpdateSubscription;
+
+  /// Subscription for events that close the current voting session.
+  StreamSubscription<Map<String, dynamic>>? _encerrarVotacaoSubscription;
+
+  /// Subscription for WebSocket connection status changes.
+  StreamSubscription<String>? _connectionSubscription;
+
+  /// Loads initial data and starts real-time synchronization.
   @override
-  /// Builds the agenda voting screen layout.
-  ///
-  /// Args:
-  ///   context: The build context used to access inherited widgets, theme
-  ///     values, and navigation.
-  ///
-  /// Returns:
-  ///   A [Scaffold] containing the app bar, voting details, vote options, and
-  ///   the confirmation button.
+  void initState() {
+    super.initState();
+    _loadVereadorData();
+    _checkExistingVote();
+    _loadEstatisticas();
+    _initializeWebSocket();
+    _startRealTimeUpdates();
+  }
+
+  /// Cancels active subscriptions and leaves the agenda WebSocket room.
+  @override
+  void dispose() {
+    _votoNotificationSubscription?.cancel();
+    _statsUpdateSubscription?.cancel();
+    _encerrarVotacaoSubscription?.cancel();
+    _connectionSubscription?.cancel();
+    _webSocketService.leavePauta(widget.pauta['id'].toString());
+    super.dispose();
+  }
+
+  /// Fetches council member details required by the authenticated session.
+  Future<void> _loadVereadorData() async {
+    try {
+      await AuthService.getVereadorDetails();
+    } catch (e) {
+      print('Erro ao carregar dados do vereador: $e');
+    }
+  }
+
+  /// Restores a previously registered vote for this agenda item when present.
+  Future<void> _checkExistingVote() async {
+    try {
+      print(
+        '🔍 Verificando se já existe voto para a pauta ${widget.pauta['id']}',
+      );
+
+      final response = await AuthService.getVotoEmPauta(
+        widget.pauta['id'].toString(),
+      );
+
+      if (response != null && response['voto'] != null) {
+        final votoData = response['voto'];
+        final votoString = votoData['voto'];
+
+        print('✅ Voto existente encontrado: $votoString');
+
+        VotoOpcao votoExistente;
+        switch (votoString) {
+          case 'SIM':
+            votoExistente = VotoOpcao.sim;
+            break;
+          case 'NÃO':
+            votoExistente = VotoOpcao.nao;
+            break;
+          case 'ABSTENÇÃO':
+            votoExistente = VotoOpcao.abstencao;
+            break;
+          default:
+            print('⚠️ Voto desconhecido: $votoString');
+            return;
+        }
+
+        if (mounted) {
+          setState(() {
+            _votoSelecionado = votoExistente;
+          });
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                'Você já votou nesta pauta: ${_getVotoDisplayName(votoExistente)}',
+              ),
+              backgroundColor: const Color(0xFF58a6ff),
+              duration: const Duration(seconds: 3),
+            ),
+          );
+        }
+      } else {
+        print('ℹ️ Nenhum voto existente encontrado para esta pauta');
+      }
+    } catch (e) {
+      print('❌ Erro ao verificar voto existente: $e');
+    }
+  }
+
+  /// Converts a [VotoOpcao] value into the label shown to the user.
+  String _getVotoDisplayName(VotoOpcao voto) {
+    switch (voto) {
+      case VotoOpcao.sim:
+        return 'SIM';
+      case VotoOpcao.nao:
+        return 'NÃO';
+      case VotoOpcao.abstencao:
+        return 'ABSTENÇÃO';
+      case VotoOpcao.nenhum:
+        return 'NENHUM';
+    }
+  }
+
+  /// Loads the current vote totals for the agenda item.
+  Future<void> _loadEstatisticas() async {
+    setState(() {
+      _isLoadingStats = true;
+    });
+
+    try {
+      print('📊 Carregando estatísticas para a pauta ${widget.pauta['id']}');
+
+      final response = await AuthService.getEstatisticasPauta(
+        widget.pauta['id'].toString(),
+      );
+
+      if (response != null && response['estatisticas'] != null) {
+        if (mounted) {
+          setState(() {
+            _estatisticas = response['estatisticas'];
+          });
+        }
+        print('✅ Estatísticas carregadas: $_estatisticas');
+      } else {
+        print('⚠️ Nenhuma estatística encontrada');
+      }
+    } catch (e) {
+      print('❌ Erro ao carregar estatísticas: $e');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingStats = false;
+        });
+      }
+    }
+  }
+
+  /// Initializes WebSocket listeners for live vote and statistics updates.
+  Future<void> _initializeWebSocket() async {
+    try {
+      _webSocketService.setContext(context);
+
+      await _webSocketService.connect();
+
+      _webSocketService.joinPauta(widget.pauta['id'].toString());
+
+      _votoNotificationSubscription = _webSocketService.votoNotifications
+          .listen((data) {
+            print('🔔 Notificação de voto recebida: $data');
+            if (data['pautaId'] != null &&
+                data['pautaId'].toString() == widget.pauta['id'].toString()) {
+              _loadEstatisticas();
+            }
+          });
+
+      _statsUpdateSubscription = _webSocketService.statsUpdates.listen((data) {
+        print('📊 Estatísticas atualizadas via WebSocket: $data');
+        if (mounted && data['estatisticas'] != null) {
+          setState(() {
+            _estatisticas = data['estatisticas'];
+          });
+        }
+      });
+
+      _encerrarVotacaoSubscription = _webSocketService.encerrarVotacaoEvents
+          .listen((data) {
+            print('🏁 Evento de encerramento de votação recebido: $data');
+            final pautaIdEncerrada = data['pautaId']?.toString();
+            if (pautaIdEncerrada == widget.pauta['id'].toString()) {
+              if (mounted) {
+                if (_votoFoiRegistrado) {
+                  String votoString;
+                  switch (_votoSelecionado) {
+                    case VotoOpcao.sim:
+                      votoString = 'SIM';
+                      break;
+                    case VotoOpcao.nao:
+                      votoString = 'NÃO';
+                      break;
+                    case VotoOpcao.abstencao:
+                      votoString = 'ABSTENÇÃO';
+                      break;
+                    default:
+                      votoString = '';
+                  }
+                  Navigator.of(
+                    context,
+                  ).pop({'votoRegistrado': true, 'voto': votoString});
+                } else {
+                  Navigator.of(context).pop(null);
+                }
+              }
+            }
+          });
+
+      _connectionSubscription = _webSocketService.connectionStatus.listen((
+        status,
+      ) {
+        if (mounted) {
+          setState(() {
+            _connectionStatus = status;
+          });
+        }
+      });
+
+      if (mounted) {
+        setState(() {
+          _connectionStatus = _webSocketService.isConnected
+              ? 'connected'
+              : 'disconnected';
+        });
+      }
+
+      print(
+        '✅ WebSocket inicializado com sucesso para a pauta ${widget.pauta['id']}',
+      );
+    } catch (e) {
+      print('❌ Erro ao inicializar WebSocket: $e');
+    }
+  }
+
+  /// Starts polling for statistics when WebSocket updates are unavailable.
+  void _startRealTimeUpdates() {
+    if (_webSocketService.isConnected) {
+      print(
+        '🔌 WebSocket ativo - usando atualizações em tempo real via WebSocket',
+      );
+      return;
+    }
+
+    print('📡 Usando polling como fallback para atualizações em tempo real');
+    Future.doWhile(() async {
+      if (!mounted) return false;
+
+      await Future.delayed(
+        const Duration(milliseconds: 1500),
+      );
+
+      if (_webSocketService.isConnected) {
+        print('🔌 WebSocket conectou - parando polling');
+        return false;
+      }
+
+      if (mounted) {
+        await _loadEstatisticas();
+      }
+
+      return mounted;
+    });
+  }
+
+  /// Validates and submits the selected vote to the backend.
+  Future<void> _submitVote() async {
+    if (_votoSelecionado == VotoOpcao.nenhum) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Por favor, selecione uma opção de voto'),
+          backgroundColor: Color(0xFFF08833),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    setState(() {
+      _isVoting = true;
+    });
+
+    try {
+      String votoString;
+      switch (_votoSelecionado) {
+        case VotoOpcao.sim:
+          votoString = 'Sim';
+          break;
+        case VotoOpcao.nao:
+          votoString = 'Não';
+          break;
+        case VotoOpcao.abstencao:
+          votoString = 'Abstenção';
+          break;
+        case VotoOpcao.nenhum:
+          return;
+      }
+
+      print('🗳️ Enviando voto: $votoString para pauta ${widget.pauta['id']}');
+
+      final response = await AuthService.registrarVoto(
+        widget.pauta['id'],
+        votoString,
+      );
+
+      if (response != null && response['success'] != false) {
+        setState(() {
+          _votoFoiRegistrado = true;
+        });
+
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Voto registrado com sucesso!'),
+            backgroundColor: Color(0xFF2EA043),
+            duration: Duration(seconds: 2),
+          ),
+        );
+
+        await _loadEstatisticas();
+      } else {
+        final errorMessage = response?['error'] ?? 'Erro ao registrar voto';
+        throw Exception(errorMessage);
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Erro ao registrar voto: $e'),
+          backgroundColor: const Color(0xFFDA3633),
+          duration: const Duration(seconds: 3),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isVoting = false;
+        });
+      }
+    }
+  }
+
+  /// Builds the voting screen layout and connection indicator.
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      // Barra de topo customizada
+      backgroundColor: const Color(0xFF0d1117),
       appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
+        backgroundColor: const Color(0xFF21262d),
+        title: const Text(
+          'Votação de Pauta',
+          style: TextStyle(color: Colors.white),
+        ),
         leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: () {
+            if (_votoFoiRegistrado) {
+              String votoString;
+              switch (_votoSelecionado) {
+                case VotoOpcao.sim:
+                  votoString = 'SIM';
+                  break;
+                case VotoOpcao.nao:
+                  votoString = 'NÃO';
+                  break;
+                case VotoOpcao.abstencao:
+                  votoString = 'ABSTENÇÃO';
+                  break;
+                default:
+                  votoString = '';
+              }
+              Navigator.of(
+                context,
+              ).pop({'votoRegistrado': true, 'voto': votoString});
+            } else {
+              Navigator.of(context).pop(null);
+            }
+          },
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
         ),
         actions: [
-          Padding(
-            padding: const EdgeInsets.only(right: 16.0),
-            child: Chip(
-              label: const Text(
-                'Em Votação',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
+          Container(
+            margin: const EdgeInsets.only(right: 16, top: 8, bottom: 8),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: _getConnectionColor(),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(_getConnectionIcon(), color: Colors.white, size: 16),
+                const SizedBox(width: 6),
+                Text(
+                  _getConnectionText(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
-              ),
-              backgroundColor: const Color(0xFFF08833),
-              padding: const EdgeInsets.symmetric(horizontal: 8),
+              ],
             ),
           ),
         ],
       ),
-      // Botão de confirmar fixo na parte inferior
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: ElevatedButton(
-          onPressed: () {
-            if (_votoSelecionado != VotoOpcao.nenhum) {
-              Navigator.of(context).pop();
-            }
-          },
-          style: ElevatedButton.styleFrom(
-            backgroundColor: const Color(0xFF2F81F7),
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8.0),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(20.0),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight:
+                  MediaQuery.of(context).size.height -
+                  AppBar().preferredSize.height -
+                  MediaQuery.of(context).padding.top -
+                  MediaQuery.of(context).padding.bottom -
+                  40,
             ),
-          ),
-          child: const Text(
-            'Confirmar Voto',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
+            child: IntrinsicHeight(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildPautaInfo(),
+                  const SizedBox(height: 20),
+                  _buildVotingOptions(),
+                  const SizedBox(height: 20),
+                  _buildEstatisticasCard(),
+                  const SizedBox(height: 20),
+                  _buildVoteButton(),
+                  const SizedBox(height: 20),
+                ],
+              ),
             ),
           ),
         ),
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
+    );
+  }
+
+  /// Builds the agenda summary card shown above the voting controls.
+  Widget _buildPautaInfo() {
+    return Card(
+      color: const Color(0xFF21262d),
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Denúncia - 2ª votação',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 24),
-            _buildInfoRow('Autor', 'Mesa Diretora da Câmara'),
-            _buildInfoRow(
-              'Descrição',
-              'Denúncia com pedido de instauração de Comissão Parlamentar de Inquérito',
-            ),
-            const SizedBox(height: 16),
-            Card(
-              child: ListTile(
-                leading: const Icon(
-                  Icons.visibility_outlined,
-                  color: Color(0xFF58A6FF),
-                ),
-                title: const Text(
-                  'Visualizar anexo',
-                  style: TextStyle(
-                    color: Color(0xFF58A6FF),
-                    fontWeight: FontWeight.bold,
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.blue.withValues(alpha: 0.2),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(color: Colors.blue, width: 1),
+                  ),
+                  child: const Text(
+                    'EM VOTAÇÃO',
+                    style: TextStyle(
+                      color: Colors.blue,
+                      fontSize: 12,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
-                onTap: () {},
-              ),
-            ),
-            const SizedBox(height: 32),
-            const Text(
-              'Escolha seu voto',
-              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ],
             ),
             const SizedBox(height: 16),
+            Text(
+              widget.pauta['nome'] ?? 'Nome da pauta não disponível',
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (widget.pauta['descricao'] != null &&
+                widget.pauta['descricao'].isNotEmpty)
+              Text(
+                widget.pauta['descricao'],
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Colors.white70,
+                  height: 1.4,
+                ),
+              ),
+            const SizedBox(height: 12),
+            if (widget.pauta['autor'] != null)
+              Row(
+                children: [
+                  const Icon(Icons.person, color: Colors.white60, size: 18),
+                  const SizedBox(width: 8),
+                  Text(
+                    'Autor: ${widget.pauta['autor']}',
+                    style: const TextStyle(fontSize: 14, color: Colors.white60),
+                  ),
+                ],
+              ),
+          ],
+        ),
+      ),
+    );
+  }
 
-            // MODIFICAÇÃO: Ícones atualizados para as versões preenchidas
-            _buildVotoOption(
-              label: 'SIM',
-              icon: Icons.check_circle, // Ícone preenchido
-              opcao: VotoOpcao.sim,
+  /// Builds the group of selectable vote options.
+  Widget _buildVotingOptions() {
+    return Card(
+      color: const Color(0xFF21262d),
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.how_to_vote, color: Colors.white, size: 20),
+                SizedBox(width: 8),
+                Text(
+                  'Seu Voto',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
             ),
-            _buildVotoOption(
-              label: 'NÃO',
-              icon: Icons.cancel, // Ícone preenchido
-              opcao: VotoOpcao.nao,
+            const SizedBox(height: 16),
+            _buildEnhancedVoteOption(
+              VotoOpcao.sim,
+              'SIM',
+              'Favorável à aprovação',
+              Colors.green,
+              Icons.thumb_up,
             ),
-            _buildVotoOption(
-              label: 'ABSTENÇÃO',
-              icon: Icons.remove_circle, // Ícone preenchido
-              opcao: VotoOpcao.abstencao,
+            const SizedBox(height: 12),
+            _buildEnhancedVoteOption(
+              VotoOpcao.nao,
+              'NÃO',
+              'Contrário à aprovação',
+              Colors.red,
+              Icons.thumb_down,
+            ),
+            const SizedBox(height: 12),
+            _buildEnhancedVoteOption(
+              VotoOpcao.abstencao,
+              'ABSTENÇÃO',
+              'Não manifesta opinião',
+              Colors.orange,
+              Icons.remove_circle_outline,
             ),
           ],
         ),
@@ -159,92 +600,339 @@ class _VotacaoPautaScreenState extends State<VotacaoPautaScreen> {
     );
   }
 
-  /// Builds a labeled information row for agenda metadata.
-  ///
-  /// Args:
-  ///   label: The field name displayed above the value.
-  ///   value: The descriptive text shown for the field.
-  ///
-  /// Returns:
-  ///   A padded widget containing the label and its corresponding value.
-  Widget _buildInfoRow(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(label, style: TextStyle(fontSize: 14, color: Colors.grey[400])),
-          const SizedBox(height: 4),
-          Text(
-            value,
-            style: const TextStyle(fontSize: 16, color: Colors.white),
+  /// Builds a selectable vote option with visual selected state.
+  Widget _buildEnhancedVoteOption(
+    VotoOpcao opcao,
+    String titulo,
+    String descricao,
+    Color cor,
+    IconData icone,
+  ) {
+    final isSelected = _votoSelecionado == opcao;
+
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          _votoSelecionado = opcao;
+        });
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 300),
+        width: double.infinity,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? cor.withValues(alpha: 0.15)
+              : const Color(0xFF0d1117),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isSelected ? cor : Colors.grey[700]!,
+            width: isSelected ? 3 : 1,
           ),
-        ],
+          boxShadow: isSelected
+              ? [
+                  BoxShadow(
+                    color: cor.withValues(alpha: 0.3),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ]
+              : null,
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: isSelected ? cor : Colors.grey[600]!,
+                  width: 2,
+                ),
+                color: isSelected ? cor : Colors.transparent,
+              ),
+              child: isSelected
+                  ? const Icon(Icons.check, color: Colors.white, size: 16)
+                  : null,
+            ),
+            const SizedBox(width: 16),
+            Icon(icone, color: isSelected ? cor : Colors.grey[400], size: 24),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    titulo,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: isSelected ? cor : Colors.white,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    descricao,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: isSelected
+                          ? cor.withValues(alpha: 0.8)
+                          : Colors.grey[400],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  /// Builds a selectable card representing a vote option.
-  ///
-  /// Args:
-  ///   label: The text displayed for the vote option.
-  ///   icon: The icon shown beside the option label.
-  ///   opcao: The vote value associated with the option.
-  ///
-  /// Returns:
-  ///   A [Card] widget that highlights the selected state and updates the
-  ///   current vote when tapped.
-  Widget _buildVotoOption({
-    required String label,
-    required IconData icon,
-    required VotoOpcao opcao,
-  }) {
-    final bool isSelected = _votoSelecionado == opcao;
+  /// Builds the vote submission button and disabled/loading states.
+  Widget _buildVoteButton() {
+    final isDisabled = _votoSelecionado == VotoOpcao.nenhum || _isVoting;
 
-    final Color optionColor;
-    switch (opcao) {
-      case VotoOpcao.sim:
-        optionColor = const Color(0xFF2EA043); // Verde
-        break;
-      case VotoOpcao.nao:
-        optionColor = const Color(0xFFDA3633); // Vermelho
-        break;
-      case VotoOpcao.abstencao:
-        optionColor = const Color(0xFFF08833); // Laranja
-        break;
-      default:
-        optionColor = Colors.grey;
-    }
-
-    return Card(
-      color: isSelected ? optionColor.withOpacity(0.15) : null,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: isSelected
-            ? BorderSide(color: optionColor, width: 2)
-            : BorderSide.none,
-      ),
-      margin: const EdgeInsets.only(bottom: 12),
-      child: ListTile(
-        onTap: () {
-          setState(() {
-            _votoSelecionado = opcao;
-          });
-        },
-        leading: Icon(
-          icon,
-          // MODIFICAÇÃO: Cor do ícone agora é permanente, não depende mais da seleção
-          color: optionColor,
-          size: 28,
-        ),
-        title: Text(
-          label,
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            color: isSelected ? optionColor : Colors.white,
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: isDisabled ? null : _submitVote,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isDisabled
+              ? Colors.grey[700]
+              : const Color(0xFF58a6ff),
+          disabledBackgroundColor: Colors.grey[700],
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
           ),
+          elevation: isDisabled ? 0 : 4,
+        ),
+        child: _isVoting
+            ? const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      color: Colors.white,
+                      strokeWidth: 2,
+                    ),
+                  ),
+                  SizedBox(width: 12),
+                  Text(
+                    'Enviando voto...',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: Colors.white,
+                    ),
+                  ),
+                ],
+              )
+            : Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.check_circle, color: Colors.white, size: 20),
+                  const SizedBox(width: 8),
+                  Text(
+                    isDisabled && !_isVoting
+                        ? 'Selecione uma opção'
+                        : 'CONFIRMAR VOTO',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: isDisabled && !_isVoting
+                          ? Colors.grey[400]
+                          : Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  /// Builds the live statistics card for the current agenda item.
+  Widget _buildEstatisticasCard() {
+    return Card(
+      color: const Color(0xFF21262d),
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Icon(Icons.bar_chart, color: Colors.white, size: 20),
+                const SizedBox(width: 8),
+                const Text(
+                  'Votos em Tempo Real',
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
+                ),
+                if (_isLoadingStats)
+                  const Padding(
+                    padding: EdgeInsets.only(left: 12),
+                    child: SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.blue,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (_estatisticas != null) ...[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _buildStatItem(
+                    'SIM',
+                    _estatisticas!['sim']?.toString() ?? '0',
+                    Colors.green,
+                    Icons.thumb_up,
+                  ),
+                  _buildStatItem(
+                    'NÃO',
+                    _estatisticas!['nao']?.toString() ?? '0',
+                    Colors.red,
+                    Icons.thumb_down,
+                  ),
+                  _buildStatItem(
+                    'ABSTENÇÃO',
+                    _estatisticas!['abstencao']?.toString() ?? '0',
+                    Colors.orange,
+                    Icons.remove_circle_outline,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(
+                  vertical: 8,
+                  horizontal: 12,
+                ),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF0d1117),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.grey[700]!),
+                ),
+                child: Text(
+                  'Total de votos: ${_estatisticas!['total']?.toString() ?? '0'}',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Colors.white70,
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ] else ...[
+              const Center(
+                child: Text(
+                  'Carregando estatísticas...',
+                  style: TextStyle(color: Colors.white70, fontSize: 14),
+                ),
+              ),
+            ],
+          ],
         ),
       ),
     );
+  }
+
+  /// Builds a single statistics tile for one vote category.
+  Widget _buildStatItem(
+    String label,
+    String count,
+    Color color,
+    IconData icon,
+  ) {
+    return Expanded(
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 4),
+        padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: color.withValues(alpha: 0.3)),
+        ),
+        child: Column(
+          children: [
+            Icon(icon, color: color, size: 24),
+            const SizedBox(height: 8),
+            Text(
+              count,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                color: color.withValues(alpha: 0.8),
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Returns the connection indicator color for the current status.
+  Color _getConnectionColor() {
+    switch (_connectionStatus) {
+      case 'connected':
+        return const Color(0xFF2EA043);
+      case 'reconnecting':
+        return const Color(0xFFF08833);
+      case 'disconnected':
+      default:
+        return const Color(0xFFDA3633);
+    }
+  }
+
+  /// Returns the connection indicator icon for the current status.
+  IconData _getConnectionIcon() {
+    switch (_connectionStatus) {
+      case 'connected':
+        return Icons.flash_on;
+      case 'reconnecting':
+        return Icons.sync;
+      case 'disconnected':
+      default:
+        return Icons.wifi_off;
+    }
+  }
+
+  /// Returns the connection indicator text for the current status.
+  String _getConnectionText() {
+    switch (_connectionStatus) {
+      case 'connected':
+        return 'Conectado';
+      case 'reconnecting':
+        return 'Reconectando...';
+      case 'disconnected':
+      default:
+        return 'Desconectado';
+    }
   }
 }


### PR DESCRIPTION
 Synchronizes the two main operational screens with the final production version. The dashboard implements paginated agenda loading (scroll-to-load), real-time cache recomputation per status tab (Pendentes / Em Votacao / Finalizadas), live voting status sanitization, and WebSocket listener hooks. The voting screen delivers the full vote registration flow with optimistic UI, HTTP polling for real-time statistics, vote duplicate detection, and back-navigation result propagation to the dashboard for immediate UI update.