### PR TITLE
feat(mobile-frontend): restructure app into Apps/ and sync entry screens

### DIFF
--- a/Apps/tablet_app/lib/login_screen.dart
+++ b/Apps/tablet_app/lib/login_screen.dart
@@ -1,112 +1,362 @@
 import 'package:flutter/material.dart';
-import 'dashboard_vereador_screen.dart'; // Importação Relativa
+import 'services/auth_service.dart';
 
-/// Displays the login interface for the digital council application.
-///
-/// This screen provides email and password input fields and a button that
-/// navigates the user to the council member dashboard.
-class LoginScreen extends StatelessWidget {
-  /// Creates the login screen widget.
-  ///
-  /// Args:
-  ///   key: The widget key used to control how this widget is identified in the
-  ///     widget tree.
+/// Centralized color palette used by the login screen.
+class AppColors {
+  /// Primary dark background for the login page.
+  static const Color backgroundDark = Color(0xFF0D1117);
+
+  /// Secondary dark surface color.
+  static const Color backgroundLight = Color(0xFF161B22);
+
+  /// Card background color for elevated login content.
+  static const Color cardBg = Color(0xFF161B22);
+
+  /// Interactive field background color.
+  static const Color hoverBg = Color(0xFF21262D);
+
+  /// Default border color for inputs and cards.
+  static const Color borderColor = Color(0xFF30363D);
+
+  /// Primary foreground color for high-emphasis text.
+  static const Color primaryText = Color(0xFFE6EDF3);
+
+  /// Secondary foreground color for hints, icons, and supporting text.
+  static const Color secondaryText = Color(0xFF8B949E);
+
+  /// Accent color used for focus states and inline actions.
+  static const Color accentBlue = Color(0xFF58A6FF);
+
+  /// Accent color used for the primary login action.
+  static const Color accentGreen = Color(0xFF2EA043);
+}
+
+/// Login page that authenticates a user and routes them to the dashboard.
+class LoginScreen extends StatefulWidget {
+  /// Creates the login screen.
   const LoginScreen({super.key});
 
   @override
-  /// Builds the login screen user interface.
-  ///
-  /// Args:
-  ///   context: The build context used to access inherited widgets, navigation,
-  ///     and theme information.
-  ///
-  /// Returns:
-  ///   A [Scaffold] containing the login form and the action button that opens
-  ///   the dashboard screen.
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+/// Manages login form state, validation, and authentication requests.
+class _LoginScreenState extends State<LoginScreen> {
+  /// Tracks whether the password field should display plain text.
+  bool _isPasswordVisible = false;
+
+  /// Prevents duplicate login submissions while authentication is in progress.
+  bool _isLoading = false;
+
+  /// Stores and reads the email value entered by the user.
+  final _emailController = TextEditingController();
+
+  /// Stores and reads the password value entered by the user.
+  final _passwordController = TextEditingController();
+
+  /// Validates the form, calls [AuthService.login], and redirects on success.
+  Future<void> _handleLogin() async {
+    final email = _emailController.text.trim();
+    final password = _passwordController.text.trim();
+
+    if (email.isEmpty || password.isEmpty) {
+      _showError('Por favor, preencha todos os campos');
+      return;
+    }
+
+    setState(() => _isLoading = true);
+
+    try {
+      final result = await AuthService.login(email, password);
+
+      if (result['success'] == true) {
+        if (!mounted) return;
+        Navigator.of(context).pushReplacementNamed('/dashboard');
+      } else {
+        _showError(result['error'] ?? 'Erro desconhecido');
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  /// Shows a floating error message using the login screen color palette.
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: AppColors.accentBlue,
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  /// Releases text editing controllers owned by this state object.
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  /// Builds the responsive login page with decorative background effects.
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: SingleChildScrollView(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 500),
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text(
-                    'Bem-vindo à Câmara Digital',
-                    style: TextStyle(
-                      fontSize: 28,
-                      fontWeight: FontWeight.bold,
-                      color: Colors.white,
-                    ),
+      body: Container(
+        decoration: const BoxDecoration(
+          color: AppColors.backgroundDark,
+          gradient: LinearGradient(
+            begin: Alignment(-0.7071, -0.7071),
+            end: Alignment(0.7071, 0.7071),
+            colors: [
+              Color.fromRGBO(88, 166, 255, 0.08),
+              Color.fromRGBO(46, 160, 67, 0.06),
+              Color.fromRGBO(138, 58, 185, 0.05),
+              Color.fromRGBO(240, 136, 51, 0.07),
+              Color.fromRGBO(88, 166, 255, 0.04),
+            ],
+            stops: [0.0, 0.25, 0.5, 0.75, 1.0],
+          ),
+        ),
+        child: Stack(
+          children: [
+            Positioned(
+              left: MediaQuery.of(context).size.width * 0.2 - 200,
+              top: MediaQuery.of(context).size.height * 0.3 - 200,
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    colors: [
+                      const Color.fromRGBO(46, 160, 67, 0.05),
+                      Colors.transparent,
+                    ],
+                    stops: const [0.0, 0.6],
                   ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Faça login para acessar sua conta',
-                    style: TextStyle(fontSize: 16, color: Colors.grey[400]),
-                  ),
-                  const SizedBox(height: 40),
-                  const Text(
-                    'E-mail',
-                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
-                  ),
-                  const SizedBox(height: 8),
-                  TextFormField(
-                    keyboardType: TextInputType.emailAddress,
-                    decoration: const InputDecoration(
-                      hintText: 'Digite seu e-mail',
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                  const Text(
-                    'Senha',
-                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
-                  ),
-                  const SizedBox(height: 8),
-                  TextFormField(
-                    obscureText: true,
-                    decoration: const InputDecoration(
-                      hintText: 'Digite sua senha',
-                    ),
-                  ),
-                  const SizedBox(height: 32),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: () {
-                        Navigator.of(context).pushReplacement(
-                          MaterialPageRoute(
-                            builder: (context) =>
-                                const DashboardVereadorScreen(),
-                          ),
-                        );
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: const Color(0xFF2F81F7),
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8.0),
-                        ),
-                      ),
-                      child: const Text(
-                        'Entrar',
-                        style: TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
-          ),
+            Positioned(
+              left: MediaQuery.of(context).size.width * 0.8 - 200,
+              top: MediaQuery.of(context).size.height * 0.7 - 200,
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    colors: [
+                      const Color.fromRGBO(138, 58, 185, 0.04),
+                      Colors.transparent,
+                    ],
+                    stops: const [0.0, 0.6],
+                  ),
+                ),
+              ),
+            ),
+            Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 24.0),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      _buildLogo(),
+                      const SizedBox(height: 40),
+                      _buildLoginCard(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );
   }
+
+  /// Builds the application logo and product name shown above the form.
+  Widget _buildLogo() {
+    return Column(
+      children: [
+        SizedBox(
+          width: 44,
+          height: 40,
+          child: CustomPaint(painter: LogoPainter()),
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Legisla Net',
+          style: TextStyle(
+            color: AppColors.primaryText,
+            fontSize: 22,
+            fontWeight: FontWeight.w600,
+            fontFamily: 'Inter',
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Builds the card that contains the login form controls.
+  Widget _buildLoginCard() {
+    return Container(
+      padding: const EdgeInsets.all(32.0),
+      decoration: BoxDecoration(
+        color: AppColors.cardBg.withValues(alpha: 0.85),
+        borderRadius: BorderRadius.circular(8.0),
+        border: Border.all(color: AppColors.borderColor),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Acesse sua conta',
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: AppColors.primaryText,
+              fontSize: 20,
+              fontWeight: FontWeight.w600,
+              fontFamily: 'Inter',
+            ),
+          ),
+          const SizedBox(height: 24),
+          _buildEmailField(),
+          const SizedBox(height: 16),
+          _buildPasswordField(),
+          const SizedBox(height: 8),
+          _buildForgotPasswordLink(),
+          const SizedBox(height: 24),
+          _buildLoginButton(),
+        ],
+      ),
+    );
+  }
+
+  /// Builds the email input field backed by [_emailController].
+  Widget _buildEmailField() {
+    return TextFormField(
+      controller: _emailController,
+      keyboardType: TextInputType.emailAddress,
+      style: const TextStyle(color: AppColors.primaryText, fontFamily: 'Inter'),
+      decoration: InputDecoration(
+        hintText: 'Digite seu email',
+        prefixIcon: const Icon(Icons.email_outlined, color: AppColors.secondaryText, size: 20),
+        filled: true,
+        fillColor: AppColors.hoverBg,
+        hintStyle: const TextStyle(color: AppColors.secondaryText, fontFamily: 'Inter'),
+        contentPadding: const EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(6.0),
+          borderSide: const BorderSide(color: AppColors.borderColor),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(6.0),
+          borderSide: const BorderSide(color: AppColors.accentBlue),
+        ),
+      ),
+    );
+  }
+
+  /// Builds the password input field and visibility toggle.
+  Widget _buildPasswordField() {
+    return TextFormField(
+      controller: _passwordController,
+      obscureText: !_isPasswordVisible,
+      style: const TextStyle(color: AppColors.primaryText, fontFamily: 'Inter'),
+      decoration: InputDecoration(
+        hintText: 'Digite sua senha',
+        prefixIcon: const Icon(Icons.lock_outline, color: AppColors.secondaryText, size: 20),
+        suffixIcon: IconButton(
+          icon: Icon(
+            _isPasswordVisible ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+            color: AppColors.secondaryText,
+            size: 20,
+          ),
+          onPressed: () => setState(() => _isPasswordVisible = !_isPasswordVisible),
+        ),
+        filled: true,
+        fillColor: AppColors.hoverBg,
+        hintStyle: const TextStyle(color: AppColors.secondaryText, fontFamily: 'Inter'),
+        contentPadding: const EdgeInsets.symmetric(vertical: 14, horizontal: 12),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(6.0),
+          borderSide: const BorderSide(color: AppColors.borderColor),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(6.0),
+          borderSide: const BorderSide(color: AppColors.accentBlue),
+        ),
+      ),
+    );
+  }
+
+  /// Builds the placeholder forgot-password action.
+  Widget _buildForgotPasswordLink() {
+    return Align(
+      alignment: Alignment.centerRight,
+      child: TextButton(
+        onPressed: () {},
+        child: const Text(
+          'Esqueceu sua senha?',
+          style: TextStyle(color: AppColors.accentBlue, fontSize: 14, fontFamily: 'Inter'),
+        ),
+      ),
+    );
+  }
+
+  /// Builds the submit button and displays a loading indicator during login.
+  Widget _buildLoginButton() {
+    return ElevatedButton(
+      onPressed: _isLoading ? null : _handleLogin,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: AppColors.accentGreen,
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6.0)),
+      ),
+      child: _isLoading
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2),
+            )
+          : const Text(
+              'Entrar',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold, color: Colors.white, fontFamily: 'Inter'),
+            ),
+    );
+  }
+}
+
+/// Paints the compact legislative building logo used on the login screen.
+class LogoPainter extends CustomPainter {
+  /// Draws the logo columns and base using the app accent gradient.
+  @override
+  void paint(Canvas canvas, Size size) {
+    final gradient = const LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [AppColors.accentBlue, AppColors.accentGreen],
+    );
+
+    final paint = Paint()
+      ..shader = gradient.createShader(Rect.fromLTWH(0, 0, size.width, size.height));
+
+    final column1 = Path()..moveTo(8, 5)..lineTo(8, 35)..lineTo(14, 35)..lineTo(14, 5)..close();
+    final column2 = Path()..moveTo(19, 5)..lineTo(19, 35)..lineTo(25, 35)..lineTo(25, 5)..close();
+    final column3 = Path()..moveTo(30, 5)..lineTo(30, 35)..lineTo(36, 35)..lineTo(36, 5)..close();
+    final base = Path()..moveTo(5, 35)..lineTo(39, 35)..lineTo(39, 40)..lineTo(5, 40)..close();
+
+    canvas.drawPath(column1, paint);
+    canvas.drawPath(column2, paint);
+    canvas.drawPath(column3, paint);
+    canvas.drawPath(base, paint);
+  }
+
+  /// Indicates that the static logo does not need to repaint.
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
 }

--- a/Apps/tablet_app/lib/main.dart
+++ b/Apps/tablet_app/lib/main.dart
@@ -1,44 +1,26 @@
 import 'package:flutter/material.dart';
-import 'login_screen.dart'; // Importação Relativa
+import 'package:flutter/services.dart';
+import 'login_screen.dart';
+import 'dashboard_vereador_screen.dart';
+import 'services/auth_service.dart';
+import 'services/update_service.dart';
 
-/// Starts the Flutter application.
-///
-/// This function initializes the widget tree by launching
-/// [CamaraDigitalApp] as the root widget.
+/// Starts the Flutter application and ensures framework services are ready.
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
   runApp(const CamaraDigitalApp());
 }
 
-/// Configures the root application widget for the digital council app.
-///
-/// This widget defines the global dark theme, application title, and initial
-/// route shown to the user.
+/// Root widget that configures the application theme, routes, and first screen.
 class CamaraDigitalApp extends StatelessWidget {
-  /// Creates the root application widget.
-  ///
-  /// Args:
-  ///   key: The widget key used to preserve this widget's identity in the
-  ///     widget tree.
+  /// Creates the Câmara Digital application shell.
   const CamaraDigitalApp({super.key});
 
+  /// Builds the app-wide Material configuration and navigation routes.
   @override
-  /// Builds the root [MaterialApp] with the shared theme configuration.
-  ///
-  /// Args:
-  ///   context: The build context used to access inherited widgets and theme
-  ///     dependencies.
-  ///
-  /// Returns:
-  ///   A [MaterialApp] configured with the application's theme and initial
-  ///   login screen.
   Widget build(BuildContext context) {
-    // Cores mais claras para o tema escuro
-    const Color corFundoPrincipal = Color(
-      0xFF1C1C1E,
-    ); // Um cinza escuro, quase preto
-    const Color corFundoCard = Color(
-      0xFF2C2C2E,
-    ); // Um cinza um pouco mais claro
+    const Color corFundoPrincipal = Color(0xFF1C1C1E);
+    const Color corFundoCard = Color(0xFF2C2C2E);
 
     return MaterialApp(
       debugShowCheckedModeBanner: false,
@@ -69,7 +51,83 @@ class CamaraDigitalApp extends StatelessWidget {
           ),
         ),
       ),
-      home: const LoginScreen(),
+      home: const SplashScreen(),
+      routes: {
+        '/login': (context) => const LoginScreen(),
+        '/dashboard': (context) => const DashboardVereadorScreen(),
+      },
     );
+  }
+}
+
+/// Initial screen responsible for checking updates and restoring authentication.
+class SplashScreen extends StatefulWidget {
+  /// Creates the splash screen used during startup initialization.
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+/// Handles startup tasks before routing the user to the proper screen.
+class _SplashScreenState extends State<SplashScreen> {
+  /// Starts the asynchronous initialization flow after the widget is inserted.
+  @override
+  void initState() {
+    super.initState();
+    _initializeApp();
+  }
+
+  /// Checks for available updates, attempts auto-login, and redirects the user.
+  Future<void> _initializeApp() async {
+    final updateData = await UpdateService.checkForUpdate();
+    if (updateData != null && mounted) {
+      await _showUpdateDialog(updateData);
+    }
+
+    final isLoggedIn = await AuthService.tryAutoLogin();
+
+    if (!mounted) return;
+    if (isLoggedIn) {
+      Navigator.of(context).pushReplacementNamed('/dashboard');
+    } else {
+      Navigator.of(context).pushReplacementNamed('/login');
+    }
+  }
+
+  /// Displays the update prompt using metadata returned by [UpdateService].
+  ///
+  /// The [data] map is expected to include the target version, release notes,
+  /// APK URL, and whether the update is required.
+  Future<void> _showUpdateDialog(Map<String, dynamic> data) async {
+    return showDialog(
+      context: context,
+      barrierDismissible: !(data['required'] ?? false),
+      builder: (context) => AlertDialog(
+        title: const Text('Nova Atualização Disponível 🚀'),
+        content: Text(
+          'Versão ${data['version']} está disponível.\n\n${data['notes'] ?? "Melhorias gerais."}',
+        ),
+        actions: [
+          if (!(data['required'] ?? false))
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Depois'),
+            ),
+          ElevatedButton(
+            onPressed: () {
+              UpdateService.launchDownloadUrl(data['apkUrl']);
+            },
+            child: const Text('Baixar Agora'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Builds a minimal loading view while startup checks are running.
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: CircularProgressIndicator()));
   }
 }

--- a/Apps/tablet_app/pubspec.yaml
+++ b/Apps/tablet_app/pubspec.yaml
@@ -1,89 +1,50 @@
 name: flutter_application_1
-description: "A new Flutter project."
-# The following line prevents the package from being accidentally published to
-# pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+description: "LegislaNet - Aplicativo Tablet para Vereadores"
+publish_to: 'none'
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number is used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# In Windows, build-name is used as the major, minor, and patch parts
-# of the product and file versions while build-number is used as the build suffix.
 version: 1.0.0+1
 
 environment:
   sdk: ^3.8.1
 
-# Dependencies specify other packages that your package needs in order to work.
-# To automatically upgrade your package dependencies to the latest versions
-# consider running `flutter pub upgrade --major-versions`. Alternatively,
-# dependencies can be manually updated by changing the version numbers below to
-# the latest version available on pub.dev. To see which dependencies have newer
-# versions available, run `flutter pub outdated`.
 dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  flutter_svg: ^2.0.7
+  http: ^1.1.0
+  url_launcher: ^6.2.4
+  wakelock_plus: ^1.2.8
+  # socket_io_client reservado para sprint de integração
+  fluttertoast: ^8.2.6
+
+  shared_preferences: ^2.2.2
+  package_info_plus: ^9.0.0
+
+  permission_handler: ^11.3.0
+  path_provider: ^2.1.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
-# The following section is specific to Flutter packages.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
 
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/to/asset-from-package
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
+  # Fontes Inter — copiar pasta fonts/ da versão final para ativar:
+  # Copy-Item -Recurse "..\..\LegislaNet\Apps\tablet_app\fonts" ".\fonts" -Force
   # fonts:
-  #   - family: Schyler
+  #   - family: Inter
   #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
+  #       - asset: fonts/Inter-Regular.ttf
+  #       - asset: fonts/Inter-Medium.ttf
+  #         weight: 500
+  #       - asset: fonts/Inter-SemiBold.ttf
+  #         weight: 600
+  #       - asset: fonts/Inter-Bold.ttf
   #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/to/font-from-package


### PR DESCRIPTION
Updates pubspec.yaml with all required production dependencies (http, shared_preferences, wakelock_plus, package_info_plus, url_launcher, fluttertoast). Rewrites main.dart with a SplashScreen that performs update checking and auto-login on startup before routing. Updates login_screen.dart to integrate the real AuthService with the AppColors palette, gradient background, and the custom SVG logo rendered via CustomPainter.