### PR TITLE
feat(web-backend): add pauta, voto and public APIs

### DIFF
--- a/src/controllers/pautaController.js
+++ b/src/controllers/pautaController.js
@@ -1,0 +1,1944 @@
+const { createClient } = require("@supabase/supabase-js");
+const createLogger = require("../utils/logger");
+const upsertAndEmitVotacaoAoVivo = () => { logger.log("Mock de upsertAndEmitVotacaoAoVivo para Sprint 12"); };
+
+const logger = createLogger("PAUTA_CONTROLLER");
+
+/**
+ * Controller actions for agenda items, voting status, and public/tablet
+ * notifications.
+ *
+ * @module controllers/pautaController
+ */
+
+/**
+ * Logs warnings through the configured logger when available.
+ *
+ * @param {...*} args - Warning values to log.
+ * @returns {void}
+ */
+const warnSeguro = (...args) => {
+  try {
+    if (logger && typeof logger.warn === "function")
+      return logger.warn(...args);
+    if (logger && typeof logger.log === "function") return logger.log(...args);
+    if (logger && typeof logger.error === "function")
+      return logger.error("WARN (fallback):", args);
+    console.warn("[PAUTA_CONTROLLER WARN]", ...args);
+  } catch (_) {
+  }
+};
+
+/**
+ * Authenticates a request using its Supabase bearer token and returns the
+ * associated profile data.
+ *
+ * @param {object} req - Express request object.
+ * @returns {Promise<object>} Authenticated user and profile metadata.
+ * @throws {Error} When the token is missing, invalid, or the profile cannot be found.
+ */
+const authenticateToken = async (req) => {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+
+  if (!token) {
+    throw new Error("Token de acesso requerido");
+  }
+
+  try {
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_ANON_KEY,
+      { global: { headers: { Authorization: `Bearer ${token}` } } },
+    );
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      logger.error("Erro ao verificar usuário:", userError);
+      throw new Error("Token inválido ou expirado");
+    }
+
+    const supabaseAdmin = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from("profiles")
+      .select("*, camaras(nome_camara)")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError || !profile) {
+      logger.error("Erro ao buscar perfil:", profileError);
+      throw new Error("Perfil não encontrado");
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      role: profile.role,
+      camara_id: profile.camara_id,
+      profile: profile,
+    };
+  } catch (error) {
+    logger.error("Erro na autenticação:", error);
+    throw new Error("Token inválido");
+  }
+};
+
+/**
+ * Lists agenda items visible to the authenticated user with filtering,
+ * pagination, and duplicate-check support.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getAllPautas = async (req, res) => {
+  try {
+    const user = await authenticateToken(req);
+
+    const { page = 1, limit = 8, status, search, autor, sessao_id } = req.query;
+    const offset = (page - 1) * limit;
+
+    logger.log(
+      `Buscando pautas para usuário ${user.id}... Página: ${page}, Limite: ${limit}, Status: "${status}", Autor: "${autor}", Busca: "${search}"`,
+    );
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    const selectWithUpdatedAt = `
+                id,
+                nome,
+                descricao,
+                anexo_url,
+                status,
+                votacao_simbolica,
+                autor,
+                created_at,
+                updated_at,
+                resultado_votacao,
+                sessoes!inner (
+                    id,
+                    nome,
+                    tipo,
+                    status,
+                    data_sessao,
+                    camara_id,
+                    camaras (nome_camara)
+                )
+            `;
+
+    const selectWithoutUpdatedAt = `
+                id,
+                nome,
+                descricao,
+                anexo_url,
+                status,
+                votacao_simbolica,
+                autor,
+                created_at,
+                resultado_votacao,
+                sessoes!inner (
+                    id,
+                    nome,
+                    tipo,
+                    status,
+                    data_sessao,
+                    camara_id,
+                    camaras (nome_camara)
+                )
+    `;
+
+    const applyFilters = (q) => {
+      if (
+        (user.role === "admin_camara" || user.role === "vereador") &&
+        user.camara_id
+      ) {
+        q = q.eq("sessoes.camara_id", user.camara_id);
+      }
+
+      if (status) {
+        q = q.eq("status", status);
+      }
+
+      if (typeof sessao_id === "string" && sessao_id.trim()) {
+        q = q.eq("sessao_id", sessao_id.trim());
+      }
+
+      if (typeof autor === "string" && autor.trim()) {
+        q = q.ilike("autor", autor.trim());
+      }
+
+      if (search) {
+        q = q.or(`nome.ilike.%${search}%,descricao.ilike.%${search}%`);
+      }
+
+      return q;
+    };
+
+    const buildBaseQuery = (selectClause) =>
+      applyFilters(
+        supabase
+          .from("pautas")
+          .select(selectClause, { count: "exact" })
+          .order("created_at", { ascending: false }),
+      );
+
+    let query = buildBaseQuery(selectWithUpdatedAt);
+
+    if (req.query.nome && req.query.sessao_id) {
+      logger.log(
+        `🔍 Verificando duplicidade: "${req.query.nome}" na sessão ${req.query.sessao_id}`,
+      );
+      query = query
+        .eq("nome", req.query.nome)
+        .eq("sessao_id", req.query.sessao_id);
+
+      let duplicatas = null;
+      let duplicataError = null;
+
+      {
+        const { data, error } = await query;
+        duplicatas = data;
+        duplicataError = error;
+      }
+
+      // Fall back when the schema does not include updated_at.
+      if (
+        duplicataError &&
+        /updated_at/i.test(duplicataError.message || duplicataError.details)
+      ) {
+        logger.warn(
+          "updated_at não disponível no schema para GET /api/pautas (duplicidade). Recuando para select sem updated_at.",
+          duplicataError,
+        );
+        query = buildBaseQuery(selectWithoutUpdatedAt)
+          .eq("nome", req.query.nome)
+          .eq("sessao_id", req.query.sessao_id);
+
+        const { data, error } = await query;
+        duplicatas = data;
+        duplicataError = error;
+      }
+
+      if (duplicataError) {
+        logger.error("Erro ao verificar duplicidade:", duplicataError);
+        return res.status(500).json({ error: "Erro ao verificar duplicidade" });
+      }
+
+      logger.log(
+        `📊 Resultado duplicidade: ${duplicatas.length} pauta(s) encontrada(s)`,
+      );
+      return res.json({ data: duplicatas });
+    }
+
+    let pautas = null;
+    let pautasError = null;
+    let count = null;
+
+    {
+      const result = await query.range(offset, offset + parseInt(limit) - 1);
+      pautas = result.data;
+      pautasError = result.error;
+      count = result.count;
+    }
+
+    // Fall back when the schema does not include updated_at.
+    if (
+      pautasError &&
+      /updated_at/i.test(pautasError.message || pautasError.details)
+    ) {
+      logger.warn(
+        "updated_at não disponível no schema para GET /api/pautas. Recuando para select sem updated_at.",
+        pautasError,
+      );
+      const retryQuery = buildBaseQuery(selectWithoutUpdatedAt);
+      const result = await retryQuery.range(
+        offset,
+        offset + parseInt(limit) - 1,
+      );
+      pautas = result.data;
+      pautasError = result.error;
+      count = result.count;
+    }
+
+    if (pautasError) {
+      logger.error("Erro ao buscar pautas:", pautasError);
+      return res.status(500).json({ error: "Erro ao buscar pautas" });
+    }
+
+    const processedPautas = (pautas || []).map((pauta) => ({
+      id: pauta.id,
+      nome: pauta.nome,
+      descricao: pauta.descricao || "",
+      anexo_url: pauta.anexo_url,
+      status: pauta.status,
+      votacao_simbolica: pauta.votacao_simbolica,
+      created_at: pauta.created_at,
+      updated_at: pauta.updated_at || pauta.created_at,
+      autor: pauta.autor || "Não informado",
+      resultado_votacao: pauta.resultado_votacao,
+      sessoes: {
+        id: pauta.sessoes?.id,
+        nome: pauta.sessoes?.nome,
+        tipo: pauta.sessoes?.tipo,
+        status: pauta.sessoes?.status,
+        data_sessao: pauta.sessoes?.data_sessao,
+        camaras: {
+          nome_camara: pauta.sessoes?.camaras?.nome_camara,
+        },
+      },
+    }));
+
+    logger.log(
+      `Encontradas ${processedPautas.length} pautas de um total de ${count} para o usuário ${user.role}.`,
+    );
+
+    res.json({
+      data: processedPautas,
+      pagination: {
+        page: parseInt(page),
+        limit: parseInt(limit),
+        total: count || 0,
+        totalPages: Math.ceil((count || 0) / limit),
+      },
+    });
+  } catch (error) {
+    logger.error("Erro no endpoint de pautas:", error);
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Lists distinct agenda authors visible to the authenticated user's camara scope.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getAutoresPautas = async (req, res) => {
+  try {
+    const user = await authenticateToken(req);
+
+    logger.log(`Buscando autores globais de pautas para usuário ${user.id}...`);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    const pageSize = 1000;
+    const maxRows = 20000;
+    let from = 0;
+
+    const autoresSet = new Set();
+
+    let sessaoIds = null;
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id
+    ) {
+      const { data: sessoes, error: sessoesError } = await supabase
+        .from("sessoes")
+        .select("id")
+        .eq("camara_id", user.camara_id);
+
+      if (sessoesError) {
+        logger.error(
+          "Erro ao buscar sessões da câmara para autores:",
+          sessoesError,
+        );
+        return res
+          .status(500)
+          .json({ error: "Erro ao buscar sessões da câmara" });
+      }
+
+      sessaoIds = (sessoes || []).map((s) => s.id).filter(Boolean);
+
+      if (sessaoIds.length === 0) {
+        return res.json({ data: [] });
+      }
+    }
+
+    const buildBaseQuery = () => {
+      let query = supabase
+        .from("pautas")
+        .select("autor")
+        .not("autor", "is", null)
+        .order("autor", { ascending: true });
+
+      if (Array.isArray(sessaoIds)) {
+        query = query.in("sessao_id", sessaoIds);
+      }
+
+      return query;
+    };
+
+    while (from < maxRows) {
+      const to = from + pageSize - 1;
+      const { data, error } = await buildBaseQuery().range(from, to);
+
+      if (error) {
+        logger.error("Erro ao buscar autores de pautas:", error);
+        return res.status(500).json({ error: "Erro ao buscar autores" });
+      }
+
+      if (!data || data.length === 0) {
+        break;
+      }
+
+      for (const row of data) {
+        const autor = typeof row.autor === "string" ? row.autor.trim() : "";
+        if (autor) autoresSet.add(autor);
+      }
+
+      if (data.length < pageSize) {
+        break;
+      }
+
+      from += pageSize;
+    }
+
+    const autores = Array.from(autoresSet).sort((a, b) =>
+      a.localeCompare(b, "pt-BR", { sensitivity: "base" }),
+    );
+
+    res.json({ data: autores });
+  } catch (error) {
+    logger.error("Erro no endpoint de autores de pautas:", error);
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Retrieves a single agenda item by id within the authenticated user's scope.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getPautaById = async (req, res) => {
+  try {
+    const user = await authenticateToken(req);
+
+    const { id } = req.params;
+
+    logger.log(`Buscando pauta ${id} para usuário ${user.id}...`);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    let query = supabase
+      .from("pautas")
+      .select(
+        `
+                *,
+                sessoes!inner (
+                    *,
+                    camaras (nome_camara)
+                ),
+                votos (
+                    id,
+                    voto,
+                    vereadores (nome_parlamentar)
+                )
+            `,
+      )
+      .eq("id", id);
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id
+    ) {
+      query = query.eq("sessoes.camara_id", user.camara_id);
+    }
+
+    const { data: pauta, error } = await query.single();
+
+    if (error) {
+      logger.error("Erro ao buscar pauta:", error);
+      if (error.code === "PGRST116") {
+        return res.status(404).json({ error: "Pauta não encontrada" });
+      }
+      return res.status(500).json({ error: "Erro ao buscar pauta" });
+    }
+
+    logger.log(`Pauta ${id} encontrada com sucesso.`);
+
+    res.json(pauta);
+  } catch (error) {
+    logger.error("Erro no endpoint de pauta específica:", error);
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Creates one or more agenda items, including an optional symbolic voting item
+ * and attached file metadata.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const createPauta = async (req, res) => {
+  logger.log("📝 === INÍCIO DO PROCESSO DE CADASTRO DE PAUTA ===");
+
+  try {
+    logger.log("🔐 Autenticando usuário...");
+    const user = await authenticateToken(req);
+    logger.log(
+      `✅ Usuário autenticado: ${user.id} (${user.email}) - Role: ${user.role}`,
+    );
+
+    const {
+      nome,
+      descricao,
+      status = "Pendente",
+      sessao_id,
+      autor,
+      votacao_simbolica,
+    } = req.body;
+
+    const criarVotacaoSimbolica =
+      votacao_simbolica === "true" || votacao_simbolica === true;
+
+    let anexo_url = null;
+    if (req.file) {
+      anexo_url = req.file.url;
+      logger.log(
+        `📎 Arquivo anexado: ${req.file.originalname} -> ${anexo_url}`,
+      );
+    }
+
+    logger.log("📋 Dados recebidos:", {
+      nome: nome || "[não informado]",
+      autor: autor || "[não informado]",
+      status,
+      sessao_id: sessao_id || "[não informado]",
+      criarVotacaoSimbolica: criarVotacaoSimbolica
+        ? "SIM (2 pautas)"
+        : "NÃO (1 pauta)",
+      descricao: descricao ? `${descricao.length} caracteres` : "[vazia]",
+      arquivo: req.file ? req.file.originalname : "[não enviado]",
+      anexo_url: anexo_url || "[nenhum]",
+    });
+
+    logger.log("🔍 Validando campos obrigatórios...");
+    if (!nome) {
+      logger.error("❌ Validação falhou: Nome da pauta não informado");
+      return res.status(400).json({ error: "Nome da pauta é obrigatório" });
+    }
+
+    if (!sessao_id) {
+      logger.error("❌ Validação falhou: Sessão não informada");
+      return res.status(400).json({ error: "Sessão é obrigatória" });
+    }
+    logger.log("✅ Campos obrigatórios validados com sucesso");
+
+    logger.log(`🚀 Iniciando criação de pauta para usuário ${user.id}...`);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    logger.log(`🔍 Verificando sessão ${sessao_id}...`);
+    const { data: sessao, error: sessaoError } = await supabase
+      .from("sessoes")
+      .select("id, camara_id, nome, status, data_sessao")
+      .eq("id", sessao_id)
+      .single();
+
+    if (sessaoError || !sessao) {
+      logger.error(`❌ Sessão não encontrada: ${sessao_id}`, sessaoError);
+      return res.status(404).json({ error: "Sessão não encontrada" });
+    }
+    logger.log(
+      `✅ Sessão encontrada: "${sessao.nome}" - Status: ${sessao.status} - Câmara: ${sessao.camara_id}`,
+    );
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id &&
+      sessao.camara_id !== user.camara_id
+    ) {
+      logger.error(
+        `❌ Acesso negado: Usuário ${user.id} tentou criar pauta para sessão de outra câmara`,
+      );
+      logger.error(
+        `   Câmara do usuário: ${user.camara_id} | Câmara da sessão: ${sessao.camara_id}`,
+      );
+      return res.status(403).json({
+        error: "Você só pode criar pautas para sessões da sua câmara",
+      });
+    }
+    logger.log("✅ Verificação de permissões aprovada");
+
+    if (autor && typeof autor !== "string") {
+      logger.error("❌ Validação falhou: Autor deve ser texto");
+      return res.status(400).json({ error: "Autor deve ser um texto" });
+    }
+    logger.log("✅ Validação do autor aprovada");
+
+    logger.log("💾 Inserindo pauta(s) no banco de dados...");
+
+    const pautasParaCriar = [];
+
+    const pautaPrincipal = {
+      nome,
+      descricao,
+      anexo_url,
+      status,
+      sessao_id,
+      autor,
+      votacao_simbolica: false,
+      resultado_votacao: "Não Votada",
+      created_by: user.id,
+    };
+    pautasParaCriar.push(pautaPrincipal);
+    logger.log("📊 Pauta principal:", pautaPrincipal);
+
+    if (criarVotacaoSimbolica) {
+      const pautaSimbolica = {
+        nome: `${nome} - Votação Simbólica`,
+        descricao: descricao
+          ? `${descricao} (Votação Simbólica)`
+          : "Votação Simbólica",
+        anexo_url,
+        status,
+        sessao_id,
+        autor,
+        votacao_simbolica: true,
+        resultado_votacao: "Não Votada",
+        created_by: user.id,
+      };
+      pautasParaCriar.push(pautaSimbolica);
+      logger.log("📊 Pauta simbólica:", pautaSimbolica);
+    }
+
+    logger.log(`🔢 Total de pautas a criar: ${pautasParaCriar.length}`);
+
+    const { data: pautas, error: pautaError } = await supabase
+      .from("pautas")
+      .insert(pautasParaCriar).select(`
+                id,
+                nome,
+                descricao,
+                anexo_url,
+                status,
+                votacao_simbolica,
+                autor,
+                created_at,
+                resultado_votacao,
+                sessoes (
+                    id,
+                    nome,
+                    tipo,
+                    status,
+                    data_sessao,
+                    camaras (nome_camara)
+                )
+            `);
+
+    if (pautaError) {
+      logger.error("❌ ERRO ao inserir pauta(s) no banco:", pautaError);
+      logger.error("📊 Dados que causaram o erro:", pautasParaCriar);
+      return res.status(500).json({ error: "Erro ao criar pauta(s)" });
+    }
+
+    logger.log(`✅ SUCESSO! ${pautas.length} pauta(s) criada(s)`);
+    pautas.forEach((pauta, index) => {
+      logger.log(`📋 Pauta ${index + 1}:`, {
+        id: pauta.id,
+        nome: pauta.nome,
+        autor: pauta.autor,
+        status: pauta.status,
+        votacao_simbolica: pauta.votacao_simbolica,
+        sessao: pauta.sessoes?.nome,
+        created_at: pauta.created_at,
+      });
+    });
+    logger.log("🎉 === CADASTRO DE PAUTA(S) CONCLUÍDO COM SUCESSO ===");
+
+    const http = require("http");
+    pautas.forEach((pauta) => {
+      const payload = JSON.stringify({
+        pautaId: pauta.id,
+        pautaNome: pauta.nome,
+        status: pauta.status,
+        camaraId: sessao.camara_id,
+      });
+
+      const options = {
+        hostname: "localhost",
+        port: 3003,
+        path: "/api/notify/nova-pauta",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+        timeout: 2000,
+      };
+
+      const request = http.request(options, (response) => {
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          logger.log(
+            `✅ Notificação de nova pauta enviada para backend tablet: ${pauta.nome}`,
+          );
+        }
+      });
+
+      request.on("error", (error) => {
+        warnSeguro(
+          `⚠️ Erro ao notificar backend tablet sobre nova pauta: ${error.message}`,
+        );
+      });
+
+      request.write(payload);
+      request.end();
+    });
+
+    res.status(201).json({
+      message: `${pautas.length} pauta(s) criada(s) com sucesso`,
+      data: pautas,
+      info: {
+        total: pautas.length,
+        principal: pautas.find((p) => !p.votacao_simbolica),
+        simbolica: pautas.find((p) => p.votacao_simbolica) || null,
+      },
+    });
+  } catch (error) {
+    logger.error(
+      "💥 ERRO CRÍTICO no endpoint de criação de pauta:",
+      error.message,
+    );
+    logger.error("📊 Stack trace:", error.stack);
+    logger.error("❌ === CADASTRO DE PAUTA FALHOU ===");
+
+    if (error.message === "Token de acesso requerido") {
+      logger.error("🔐 Erro de autenticação: Token ausente");
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      logger.error(
+        "🔐 Erro de autenticação: Token inválido ou usuário não encontrado",
+      );
+      return res.status(401).json({ error: error.message });
+    }
+
+    logger.error("💀 Erro interno não tratado, retornando erro 500");
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Updates the stored voting result for an agenda item.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const updateResultadoVotacao = async (req, res) => {
+  logger.log("📝 === INÍCIO DA ATUALIZAÇÃO DE RESULTADO DE VOTAÇÃO ===");
+
+  try {
+    logger.log("🔐 Autenticando usuário...");
+    const user = await authenticateToken(req);
+    logger.log(
+      `✅ Usuário autenticado: ${user.id} (${user.email}) - Role: ${user.role}`,
+    );
+
+    const { id } = req.params;
+    const { resultado_votacao } = req.body;
+
+    logger.log("📋 Dados recebidos:", {
+      pauta_id: id,
+      novo_resultado: resultado_votacao,
+      usuario: user.id,
+    });
+
+    if (!id) {
+      logger.error("❌ Validação falhou: ID da pauta não informado");
+      return res.status(400).json({ error: "ID da pauta é obrigatório" });
+    }
+
+    if (!resultado_votacao) {
+      logger.error("❌ Validação falhou: Resultado da votação não informado");
+      return res
+        .status(400)
+        .json({ error: "Resultado da votação é obrigatório" });
+    }
+
+    const resultadosPermitidos = ["Não Votada", "Aprovada", "Reprovada"];
+    if (!resultadosPermitidos.includes(resultado_votacao)) {
+      logger.error(
+        "❌ Validação falhou: Resultado inválido",
+        resultado_votacao,
+      );
+      return res.status(400).json({
+        error:
+          "Resultado inválido. Permitidos: " + resultadosPermitidos.join(", "),
+      });
+    }
+
+    logger.log(
+      `🚀 Atualizando resultado da pauta ${id} para "${resultado_votacao}"...`,
+    );
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    logger.log(`🔍 Verificando pauta ${id}...`);
+    const { data: pauta, error: pautaError } = await supabase
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                resultado_votacao,
+                sessao_id,
+                sessoes!inner (
+                    id,
+                    camara_id
+                )
+            `,
+      )
+      .eq("id", id)
+      .single();
+
+    if (pautaError || !pauta) {
+      logger.error(`❌ Pauta não encontrada: ${id}`, pautaError);
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    logger.log(
+      `✅ Pauta encontrada: "${pauta.nome}" - Resultado atual: ${pauta.resultado_votacao}`,
+    );
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id &&
+      pauta.sessoes.camara_id !== user.camara_id
+    ) {
+      logger.error(
+        `❌ Acesso negado: Usuário ${user.id} tentou alterar pauta de outra câmara`,
+      );
+      return res
+        .status(403)
+        .json({ error: "Você só pode alterar pautas da sua câmara" });
+    }
+
+    logger.log("💾 Atualizando resultado no banco de dados...");
+    const { data: pautaAtualizada, error: updateError } = await supabase
+      .from("pautas")
+      .update({
+        resultado_votacao: resultado_votacao,
+      })
+      .eq("id", id)
+      .select(
+        `
+                id,
+                nome,
+                resultado_votacao,
+                created_at
+            `,
+      )
+      .single();
+
+    if (updateError) {
+      logger.error("❌ ERRO ao atualizar resultado da votação:", updateError);
+      return res
+        .status(500)
+        .json({ error: "Erro ao atualizar resultado da votação" });
+    }
+
+    logger.log(`✅ SUCESSO! Resultado da votação atualizado:`, {
+      id: pautaAtualizada.id,
+      nome: pautaAtualizada.nome,
+      resultado_anterior: pauta.resultado_votacao,
+      resultado_novo: pautaAtualizada.resultado_votacao,
+      created_at: pautaAtualizada.created_at,
+    });
+
+    logger.log(
+      "🎉 === ATUALIZAÇÃO DE RESULTADO DE VOTAÇÃO CONCLUÍDA COM SUCESSO ===",
+    );
+
+    res.json({
+      message: "Resultado da votação atualizado com sucesso",
+      data: pautaAtualizada,
+    });
+  } catch (error) {
+    logger.error("💥 ERRO CRÍTICO na atualização de resultado:", error.message);
+    logger.error("📊 Stack trace:", error.stack);
+    logger.error("❌ === ATUALIZAÇÃO DE RESULTADO FALHOU ===");
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Updates agenda status, recalculates voting results when finalized, and emits
+ * tablet/public notification events.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const updatePautaStatus = async (req, res) => {
+  logger.log("📝 === INÍCIO DA ATUALIZAÇÃO DE STATUS DE PAUTA ===");
+
+  try {
+    logger.log("🔐 Autenticando usuário...");
+    const user = await authenticateToken(req);
+    logger.log(
+      `✅ Usuário autenticado: ${user.id} (${user.email}) - Role: ${user.role}`,
+    );
+
+    const { id } = req.params;
+    const { status } = req.body;
+
+    logger.log("📋 Dados recebidos:", {
+      pauta_id: id,
+      novo_status: status,
+      usuario: user.id,
+    });
+
+    if (!id) {
+      logger.error("❌ Validação falhou: ID da pauta não informado");
+      return res.status(400).json({ error: "ID da pauta é obrigatório" });
+    }
+
+    if (!status) {
+      logger.error("❌ Validação falhou: Status não informado");
+      return res.status(400).json({ error: "Status é obrigatório" });
+    }
+
+    const statusPermitidos = ["Pendente", "Em Votação", "Finalizada"];
+    if (!statusPermitidos.includes(status)) {
+      logger.error("❌ Validação falhou: Status inválido", status);
+      return res.status(400).json({
+        error: "Status inválido. Permitidos: " + statusPermitidos.join(", "),
+      });
+    }
+
+    logger.log(`🚀 Atualizando status da pauta ${id} para "${status}"...`);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    logger.log(`🔍 Verificando pauta ${id}...`);
+    const { data: pauta, error: pautaError } = await supabase
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                status,
+                sessao_id,
+                sessoes!inner (
+                    id,
+                    camara_id
+                )
+            `,
+      )
+      .eq("id", id)
+      .single();
+
+    if (pautaError || !pauta) {
+      logger.error(`❌ Pauta não encontrada: ${id}`, pautaError);
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    logger.log(
+      `✅ Pauta encontrada: "${pauta.nome}" - Status atual: ${pauta.status}`,
+    );
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id &&
+      pauta.sessoes.camara_id !== user.camara_id
+    ) {
+      logger.error(
+        `❌ Acesso negado: Usuário ${user.id} tentou alterar pauta de outra câmara`,
+      );
+      return res
+        .status(403)
+        .json({ error: "Você só pode alterar pautas da sua câmara" });
+    }
+
+    logger.log("💾 Atualizando status no banco de dados...");
+
+    // Keep live-vote state aligned with the agenda status.
+    const updatePayload = { status };
+    if (status === "Em Votação") {
+      updatePayload.ao_vivo = true;
+    } else {
+      updatePayload.ao_vivo = false;
+    }
+
+    let { data: pautaAtualizada, error: updateError } = await supabase
+      .from("pautas")
+      .update(updatePayload)
+      .eq("id", id)
+      .select(
+        `
+                id,
+                nome,
+                status,
+                created_at,
+                updated_at
+            `,
+      )
+      .single();
+
+    // Fall back when older schemas do not include the ao_vivo column.
+    if (updateError) {
+      const msg = (updateError?.message || "").toLowerCase();
+      const missingAoVivoColumn =
+        msg.includes("ao_vivo") &&
+        (msg.includes("does not exist") ||
+          msg.includes("column") ||
+          msg.includes("schema"));
+      if (missingAoVivoColumn) {
+        logger.log(
+          "⚠️ Coluna ao_vivo ausente; atualizando apenas status (fallback compatível)",
+        );
+        ({ data: pautaAtualizada, error: updateError } = await supabase
+          .from("pautas")
+          .update({ status })
+          .eq("id", id)
+          .select(
+            `
+                    id,
+                    nome,
+                    status,
+                    created_at,
+                    updated_at
+                `,
+          )
+          .single());
+      }
+    }
+
+    if (updateError) {
+      logger.error("❌ ERRO ao atualizar status da pauta:", updateError);
+      return res
+        .status(500)
+        .json({ error: "Erro ao atualizar status da pauta" });
+    }
+
+    if (status === "Finalizada") {
+      logger.log("🗳️ Pauta finalizada - iniciando contagem de votos...");
+      await _calcularResultadoVotacao(supabase, id, logger);
+
+      const { data: pautaFinalizada } = await supabase
+        .from("pautas")
+        .select("*, sessoes!inner(camara_id)")
+        .eq("id", id)
+        .single();
+
+      if (pautaFinalizada) {
+        pautaAtualizada = pautaFinalizada;
+      }
+    }
+
+    try {
+      const appRef = req.app;
+      const notificationPayload = {
+        pautaId: id,
+        pautaNome: pautaAtualizada.nome,
+        oldStatus: pauta.status,
+        newStatus: pautaAtualizada.status,
+        resultado: pautaAtualizada.resultado_votacao || null,
+        camaraId: pautaAtualizada.sessoes?.camara_id,
+      };
+
+      const http = require("http");
+      const postData = JSON.stringify(notificationPayload);
+
+      const options = {
+        hostname: "localhost",
+        port: 3003,
+        path: "/api/notify/pauta-status-change",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData),
+        },
+      };
+
+      const req = http.request(options, (res) => {
+        res.on("data", () => {});
+        res.on("end", () => {});
+
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          logger.log("📡 Notificação para tablet backend enviada com sucesso");
+        } else {
+          warnSeguro(
+            "⚠️ Falha ao enviar notificação para tablet backend:",
+            res.statusCode,
+          );
+        }
+      });
+
+      req.setTimeout(2500, () => {
+        try {
+          warnSeguro("⚠️ Timeout ao notificar tablet backend");
+          req.destroy(new Error("timeout"));
+        } catch (_) {
+        }
+      });
+
+      req.on("error", (error) => {
+        try {
+          warnSeguro("⚠️ Erro ao notificar tablet backend:", error.message);
+        } catch (_) {
+        }
+      });
+
+      req.write(postData);
+      req.end();
+
+      // Notify tablet clients to close any active voting screen after finalization.
+      if (
+        status === "Finalizada" &&
+        pautaAtualizada?.sessoes?.camara_id &&
+        pautaAtualizada?.nome
+      ) {
+        try {
+          const postDataEncerrar = JSON.stringify({
+            camaraId: pautaAtualizada.sessoes.camara_id,
+            pautaId: id,
+            pautaNome: pautaAtualizada.nome,
+            resultado: pautaAtualizada.resultado_votacao || null,
+          });
+
+          const optionsEncerrar = {
+            hostname: "localhost",
+            port: 3003,
+            path: "/api/notify/encerrar-votacao",
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Content-Length": Buffer.byteLength(postDataEncerrar),
+            },
+          };
+
+          const reqEncerrar = http.request(optionsEncerrar, (res) => {
+            res.on("data", () => {});
+            res.on("end", () => {});
+          });
+
+          reqEncerrar.setTimeout(2500, () => {
+            try {
+              reqEncerrar.destroy(new Error("timeout"));
+            } catch (_) {}
+          });
+
+          reqEncerrar.on("error", () => {
+          });
+
+          reqEncerrar.write(postDataEncerrar);
+          reqEncerrar.end();
+        } catch (_) {
+        }
+      }
+
+      if (
+        status === "Finalizada" &&
+        typeof global !== "undefined" &&
+        global.io
+      ) {
+        logger.log(
+          "📡 Emitindo notificação para portal público: pauta finalizada",
+        );
+
+        // Prefer updated_at when the schema supports it.
+        let pautaCompleta = null;
+        try {
+          const resp = await supabase
+            .from("pautas")
+            .select(
+              `
+                            id,
+                            nome,
+                            descricao,
+                            autor,
+                            resultado_votacao,
+                            created_at,
+                            updated_at,
+                            sessoes!inner (
+                                nome,
+                                data_sessao,
+                                camara_id
+                            )
+                        `,
+            )
+            .eq("id", id)
+            .single();
+
+          if (resp.error) throw resp.error;
+          pautaCompleta = resp.data;
+        } catch (err) {
+          warnSeguro(
+            "updated_at não disponível ou erro ao buscar pauta com updated_at, recuando para select sem updated_at:",
+            err.message || err,
+          );
+          const resp2 = await supabase
+            .from("pautas")
+            .select(
+              `
+                            id,
+                            nome,
+                            descricao,
+                            autor,
+                            resultado_votacao,
+                            created_at,
+                            sessoes!inner (
+                                nome,
+                                data_sessao,
+                                camara_id
+                            )
+                        `,
+            )
+            .eq("id", id)
+            .single();
+
+          if (resp2.error) {
+            warnSeguro(
+              "Erro ao buscar pauta completa para notificação do portal:",
+              resp2.error.message || resp2.error,
+            );
+          } else {
+            pautaCompleta = resp2.data;
+          }
+        }
+
+        if (pautaCompleta) {
+          const eventData = {
+            camaraId: pautaCompleta.sessoes.camara_id,
+            pauta: {
+              id: pautaCompleta.id,
+              nome: pautaCompleta.nome,
+              descricao: pautaCompleta.descricao,
+              autor: pautaCompleta.autor,
+              resultado_votacao: pautaCompleta.resultado_votacao,
+              created_at: pautaCompleta.created_at,
+              updated_at: pautaCompleta.updated_at || pautaCompleta.created_at,
+              sessao: {
+                nome: pautaCompleta.sessoes.nome,
+                data_sessao: pautaCompleta.sessoes.data_sessao,
+              },
+            },
+            timestamp: new Date().toISOString(),
+          };
+
+          global.io
+            .to(`portal-camara-${pautaCompleta.sessoes.camara_id}`)
+            .emit("pauta-finalizada", eventData);
+
+          global.io
+            .to(`tv-camara-${pautaCompleta.sessoes.camara_id}`)
+            .emit("tv:encerrar-votacao", {
+              pautaId: pautaCompleta.id,
+              camaraId: pautaCompleta.sessoes.camara_id,
+              timestamp: new Date().toISOString(),
+            });
+
+          global.io
+            .to(`tv-camara-${pautaCompleta.sessoes.camara_id}`)
+            .emit("votacao-finalizada", { pautaId: pautaCompleta.id });
+
+          logger.log(
+            `📡 Notificação emitida para portal da câmara ${pautaCompleta.sessoes.camara_id}`,
+          );
+          logger.log(
+            `📺 Notificação de encerramento emitida para TVs da câmara ${pautaCompleta.sessoes.camara_id}`,
+          );
+
+          // Clear live voting state so public clients do not remain marked as live.
+          try {
+            upsertAndEmitVotacaoAoVivo(appRef, {
+              camaraId: pautaCompleta.sessoes.camara_id,
+              pautaId: pautaCompleta.id,
+              pautaNome: pautaCompleta.nome,
+              pautaDescricao: pautaCompleta.descricao,
+              sessaoNome: pautaCompleta.sessoes.nome,
+              sessaoTipo: "",
+              sessaoDataHora: pautaCompleta.sessoes.data_sessao,
+              vereadoresOnline: 0,
+              status: "encerrada",
+              timestamp: new Date().toISOString(),
+            });
+          } catch (err) {
+            warnSeguro(
+              "⚠️ Falha ao atualizar estado de votação ao vivo (encerrada):",
+              err?.message || err,
+            );
+          }
+        } else {
+          warnSeguro(
+            "⚠️ Não foi possível buscar dados completos da pauta para notificação do portal",
+          );
+        }
+      }
+    } catch (notificationError) {
+      warnSeguro(
+        "⚠️ Erro ao notificar via WebSocket:",
+        notificationError.message,
+      );
+    }
+
+    logger.log(`✅ SUCESSO! Status da pauta atualizado:`, {
+      id: pautaAtualizada.id,
+      nome: pautaAtualizada.nome,
+      status_anterior: pauta.status,
+      status_novo: pautaAtualizada.status,
+      resultado_votacao: pautaAtualizada.resultado_votacao,
+      created_at: pautaAtualizada.created_at,
+    });
+
+    logger.log("🎉 === ATUALIZAÇÃO DE STATUS CONCLUÍDA COM SUCESSO ===");
+
+    res.json({
+      message: "Status da pauta atualizado com sucesso",
+      data: pautaAtualizada,
+    });
+  } catch (error) {
+    logger.error("💥 ERRO CRÍTICO na atualização de status:", error.message);
+    logger.error("📊 Stack trace:", error.stack);
+    logger.error("❌ === ATUALIZAÇÃO DE STATUS FALHOU ===");
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Deletes an agenda item after permission checks and blocks deletion when votes exist.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const deletePauta = async (req, res) => {
+  logger.log("🗑️ === INÍCIO DO PROCESSO DE REMOÇÃO DE PAUTA ===");
+
+  try {
+    logger.log("🔐 Autenticando usuário...");
+    const user = await authenticateToken(req);
+    logger.log(
+      `✅ Usuário autenticado: ${user.id} (${user.email}) - Role: ${user.role}`,
+    );
+
+    const { id } = req.params;
+
+    logger.log("📋 Dados recebidos:", {
+      pauta_id: id,
+      usuario: user.id,
+    });
+
+    if (!id) {
+      logger.error("❌ Validação falhou: ID da pauta não informado");
+      return res.status(400).json({ error: "ID da pauta é obrigatório" });
+    }
+
+    logger.log(`🚀 Iniciando remoção da pauta ${id}...`);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    logger.log(`🔍 Verificando pauta ${id}...`);
+    const { data: pauta, error: pautaError } = await supabase
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                status,
+                sessao_id,
+                votacao_simbolica,
+                sessoes!inner (
+                    id,
+                    camara_id,
+                    nome
+                ),
+                votos (
+                    id,
+                    voto
+                )
+            `,
+      )
+      .eq("id", id)
+      .single();
+
+    if (pautaError || !pauta) {
+      logger.error(`❌ Pauta não encontrada: ${id}`, pautaError);
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    logger.log(
+      `✅ Pauta encontrada: "${pauta.nome}" - Status: ${pauta.status}`,
+    );
+    logger.log(`📊 Votos registrados: ${pauta.votos ? pauta.votos.length : 0}`);
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id &&
+      pauta.sessoes.camara_id !== user.camara_id
+    ) {
+      logger.error(
+        `❌ Acesso negado: Usuário ${user.id} tentou remover pauta de outra câmara`,
+      );
+      return res
+        .status(403)
+        .json({ error: "Você só pode remover pautas da sua câmara" });
+    }
+
+    if (pauta.votos && pauta.votos.length > 0) {
+      logger.error(
+        `❌ Remoção bloqueada: Pauta possui ${pauta.votos.length} voto(s) registrado(s)`,
+      );
+      return res.status(400).json({
+        error:
+          "Não é possível remover uma pauta que já possui votos registrados",
+        details: `Esta pauta possui ${pauta.votos.length} voto(s) registrado(s)`,
+      });
+    }
+
+    logger.log("✅ Validação de votos aprovada - nenhum voto encontrado");
+
+    logger.log("🗑️ Removendo pauta do banco de dados...");
+    const { error: deleteError } = await supabase
+      .from("pautas")
+      .delete()
+      .eq("id", id);
+
+    if (deleteError) {
+      logger.error("❌ ERRO ao remover pauta:", deleteError);
+      return res.status(500).json({ error: "Erro ao remover pauta" });
+    }
+
+    logger.log(`✅ SUCESSO! Pauta removida:`, {
+      id: pauta.id,
+      nome: pauta.nome,
+      status: pauta.status,
+      sessao: pauta.sessoes.nome,
+      votacao_simbolica: pauta.votacao_simbolica,
+    });
+
+    logger.log("🎉 === REMOÇÃO DE PAUTA CONCLUÍDA COM SUCESSO ===");
+
+    res.json({
+      message: "Pauta removida com sucesso",
+      data: {
+        id: pauta.id,
+        nome: pauta.nome,
+        sessao: pauta.sessoes.nome,
+      },
+    });
+  } catch (error) {
+    logger.error("💥 ERRO CRÍTICO na remoção de pauta:", error.message);
+    logger.error("📊 Stack trace:", error.stack);
+    logger.error("❌ === REMOÇÃO DE PAUTA FALHOU ===");
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Updates an agenda item while enforcing vote, session-date, and camara-scope rules.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const updatePauta = async (req, res) => {
+  logger.log("✏️ === INÍCIO DO PROCESSO DE EDIÇÃO DE PAUTA ===");
+
+  try {
+    logger.log("🔐 Autenticando usuário...");
+    const user = await authenticateToken(req);
+    logger.log(
+      `✅ Usuário autenticado: ${user.id} (${user.email}) - Role: ${user.role}`,
+    );
+
+    const { id } = req.params;
+    const {
+      nome,
+      descricao,
+      status,
+      autor,
+      sessao_id,
+    } = req.body;
+
+    let anexo_url = undefined;
+    if (req.file) {
+      anexo_url = req.file.url;
+      logger.log(
+        `📎 Novo arquivo anexado: ${req.file.originalname} -> ${anexo_url}`,
+      );
+    }
+
+    logger.log("📋 Dados recebidos para edição:", {
+      pauta_id: id,
+      nome: nome || "[não alterado]",
+      autor: autor || "[não alterado]",
+      status: status || "[não alterado]",
+      sessao_id: sessao_id || "[não alterado]",
+      descricao: descricao
+        ? `${descricao.length} caracteres`
+        : "[não alterado]",
+      arquivo: req.file ? req.file.originalname : "[não alterado]",
+      usuario: user.id,
+    });
+
+    logger.log("🔍 Validando campos...");
+    if (!id) {
+      logger.error("❌ Validação falhou: ID da pauta não informado");
+      return res.status(400).json({ error: "ID da pauta é obrigatório" });
+    }
+
+    if (nome && nome.trim().length === 0) {
+      logger.error("❌ Validação falhou: Nome da pauta não pode estar vazio");
+      return res
+        .status(400)
+        .json({ error: "Nome da pauta não pode estar vazio" });
+    }
+
+    if (status && !["Pendente", "Em Votação", "Finalizada"].includes(status)) {
+      logger.error("❌ Validação falhou: Status inválido", status);
+      return res.status(400).json({ error: "Status inválido" });
+    }
+    logger.log("✅ Campos validados com sucesso");
+
+    logger.log(`🚀 Iniciando edição da pauta ${id}...`);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY,
+    );
+
+    logger.log(`🔍 Verificando pauta ${id}...`);
+    const { data: pautaAtual, error: pautaError } = await supabase
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                descricao,
+                status,
+                autor,
+                anexo_url,
+                votacao_simbolica,
+                resultado_votacao,
+                sessao_id,
+                sessoes!inner (
+                    id,
+                    nome,
+                    camara_id,
+                    data_sessao,
+                    status
+                ),
+                votos (
+                    id,
+                    voto
+                )
+            `,
+      )
+      .eq("id", id)
+      .single();
+
+    if (pautaError || !pautaAtual) {
+      logger.error(`❌ Pauta não encontrada: ${id}`, pautaError);
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    logger.log(
+      `✅ Pauta encontrada: "${pautaAtual.nome}" - Status: ${pautaAtual.status}`,
+    );
+    logger.log(
+      `📊 Votos registrados: ${pautaAtual.votos ? pautaAtual.votos.length : 0}`,
+    );
+    logger.log(`📅 Data da sessão: ${pautaAtual.sessoes?.data_sessao}`);
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id &&
+      pautaAtual.sessoes.camara_id !== user.camara_id
+    ) {
+      logger.error(
+        `❌ Acesso negado: Usuário ${user.id} tentou editar pauta de outra câmara`,
+      );
+      return res
+        .status(403)
+        .json({ error: "Você só pode editar pautas da sua câmara" });
+    }
+
+    logger.log("🔒 Aplicando validações de edição...");
+
+    const agora = new Date();
+    const dataSessao = new Date(pautaAtual.sessoes.data_sessao);
+
+    // Allow moving a past-session agenda item only when it has no votes.
+    const isRemanejamento = sessao_id && sessao_id !== pautaAtual.sessao_id;
+    const temVotos = pautaAtual.votos && pautaAtual.votos.length > 0;
+
+    if (agora > dataSessao) {
+      if (!isRemanejamento || temVotos) {
+        logger.error(
+          `❌ Edição bloqueada: Data da sessão já passou (${dataSessao.toISOString()} < ${agora.toISOString()})`,
+        );
+
+        let errorMessage =
+          "Não é possível editar uma pauta após o término da sessão";
+        if (isRemanejamento && temVotos) {
+          errorMessage =
+            "Não é possível remanejar uma pauta que já possui votos registrados.";
+        }
+
+        return res.status(400).json({
+          error: errorMessage,
+          details: isRemanejamento
+            ? "Pautas com votos não podem ser remanejadas."
+            : `A sessão ocorreu em ${dataSessao.toLocaleDateString(
+                "pt-BR",
+              )} às ${dataSessao.toLocaleTimeString("pt-BR")}`,
+        });
+      }
+      logger.log(
+        "⚠️ Edição permitida EXCEPCIONALMENTE: Remanejamento de sessão passada (sem votos)",
+      );
+    }
+    logger.log("✅ Validação de data aprovada - sessão ainda não ocorreu");
+
+    if (
+      pautaAtual.status === "Finalizada" &&
+      pautaAtual.votos &&
+      pautaAtual.votos.length > 0
+    ) {
+      logger.error(
+        `❌ Edição bloqueada: Pauta finalizada possui ${pautaAtual.votos.length} voto(s) registrado(s)`,
+      );
+      return res.status(400).json({
+        error:
+          "Não é possível editar uma pauta finalizada que já possui votos registrados",
+        details: `Esta pauta possui ${pautaAtual.votos.length} voto(s) registrado(s)`,
+      });
+    }
+    logger.log("✅ Validação de status/votos aprovada");
+
+    if (sessao_id && sessao_id !== pautaAtual.sessao_id) {
+      logger.log(
+        `🔄 Validando mudança de sessão: ${pautaAtual.sessao_id} → ${sessao_id}`,
+      );
+
+      const { data: novaSessao, error: sessaoError } = await supabase
+        .from("sessoes")
+        .select("id, nome, camara_id, data_sessao, status")
+        .eq("id", sessao_id)
+        .single();
+
+      if (sessaoError || !novaSessao) {
+        logger.error(
+          `❌ Nova sessão não encontrada: ${sessao_id}`,
+          sessaoError,
+        );
+        return res.status(404).json({ error: "Sessão não encontrada" });
+      }
+
+      if (
+        (user.role === "admin_camara" || user.role === "vereador") &&
+        novaSessao.camara_id !== user.camara_id
+      ) {
+        logger.error(`❌ Nova sessão pertence a outra câmara`);
+        return res.status(403).json({
+          error: "Você só pode mover pautas para sessões da sua câmara",
+        });
+      }
+
+      const novaDataSessao = new Date(novaSessao.data_sessao);
+      if (agora > novaDataSessao) {
+        logger.error(
+          `❌ Nova sessão já ocorreu: ${novaDataSessao.toISOString()}`,
+        );
+        return res.status(400).json({
+          error: "Não é possível mover pauta para uma sessão que já ocorreu",
+        });
+      }
+
+      logger.log(`✅ Nova sessão aprovada: "${novaSessao.nome}"`);
+    }
+
+    const dadosParaAtualizar = {};
+    if (nome !== undefined) dadosParaAtualizar.nome = nome.trim();
+    if (descricao !== undefined)
+      dadosParaAtualizar.descricao = descricao?.trim() || "";
+    if (status !== undefined) dadosParaAtualizar.status = status;
+    if (autor !== undefined) dadosParaAtualizar.autor = autor?.trim() || "";
+    if (sessao_id !== undefined) dadosParaAtualizar.sessao_id = sessao_id;
+    if (anexo_url !== undefined) dadosParaAtualizar.anexo_url = anexo_url;
+
+    logger.log("💾 Atualizando pauta no banco de dados...");
+    logger.log("📋 Campos a atualizar:", Object.keys(dadosParaAtualizar));
+
+    const { data: pautaAtualizada, error: updateError } = await supabase
+      .from("pautas")
+      .update(dadosParaAtualizar)
+      .eq("id", id)
+      .select(
+        `
+                id,
+                nome,
+                descricao,
+                status,
+                autor,
+                anexo_url,
+                votacao_simbolica,
+                resultado_votacao,
+                created_at,
+                sessoes (
+                    id,
+                    nome,
+                    tipo,
+                    status,
+                    data_sessao,
+                    camaras (nome_camara)
+                )
+            `,
+      )
+      .single();
+
+    if (updateError) {
+      logger.error("❌ ERRO ao atualizar pauta:", updateError);
+      return res.status(500).json({ error: "Erro ao atualizar pauta" });
+    }
+
+    logger.log(`✅ SUCESSO! Pauta atualizada:`, {
+      id: pautaAtualizada.id,
+      nome: pautaAtualizada.nome,
+      status: pautaAtualizada.status,
+      autor: pautaAtualizada.autor,
+      sessao: pautaAtualizada.sessoes?.nome,
+      created_at: pautaAtualizada.created_at,
+    });
+
+    logger.log("🎉 === EDIÇÃO DE PAUTA CONCLUÍDA COM SUCESSO ===");
+
+    res.json({
+      message: "Pauta atualizada com sucesso",
+      data: pautaAtualizada,
+    });
+  } catch (error) {
+    logger.error("💥 ERRO CRÍTICO na edição de pauta:", error.message);
+    logger.error("📊 Stack trace:", error.stack);
+    logger.error("❌ === EDIÇÃO DE PAUTA FALHOU ===");
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Usuário não encontrado" ||
+      error.message === "Token inválido"
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Calculates and stores the final voting result for an agenda item.
+ *
+ * @param {object} supabase - Supabase client used for vote and agenda updates.
+ * @param {string} pautaId - Agenda item identifier.
+ * @param {object} logger - Logger used for calculation diagnostics.
+ * @returns {Promise<void>}
+ */
+const _calcularResultadoVotacao = async (supabase, pautaId, logger) => {
+  try {
+    logger.log("📊 Buscando votos da pauta...");
+
+    const { data: votos, error: votosError } = await supabase
+      .from("votos")
+      .select(
+        `
+                id,
+                voto,
+                era_presidente_no_voto,
+                vereadores (
+                    id,
+                    nome_parlamentar
+                )
+            `,
+      )
+      .eq("pauta_id", pautaId);
+
+    if (votosError) {
+      logger.error("❌ Erro ao buscar votos:", votosError);
+      return;
+    }
+
+    logger.log(`📋 Total de votos encontrados: ${votos.length}`);
+
+    const votoPresidente = votos.find((v) => v.era_presidente_no_voto);
+
+    // Count regular votes separately because the president only breaks ties.
+    const votosNaoPresidentes = votos.filter((v) => !v.era_presidente_no_voto);
+    const votosSim = votosNaoPresidentes.filter((v) => v.voto === "SIM").length;
+    const votosNao = votosNaoPresidentes.filter((v) => v.voto === "NÃO").length;
+    const abstencoes = votosNaoPresidentes.filter(
+      (v) => v.voto === "ABSTENÇÃO",
+    ).length;
+
+    logger.log("📊 Contagem de votos (sem presidente):", {
+      sim: votosSim,
+      nao: votosNao,
+      abstencoes: abstencoes,
+      voto_presidente: votoPresidente?.voto || "Não votou",
+    });
+
+    let resultado;
+
+    if (votosSim > votosNao) {
+      resultado = "Aprovada";
+      logger.log("✅ Resultado: APROVADA (maioria simples dos vereadores)");
+    } else if (votosSim < votosNao) {
+      resultado = "Reprovada";
+      logger.log("❌ Resultado: REPROVADA (maioria simples dos vereadores)");
+    } else {
+      if (votoPresidente) {
+        if (votoPresidente.voto === "SIM") {
+          resultado = "Aprovada";
+          logger.log(
+            "✅ Resultado: APROVADA (empate + voto de minerva do presidente: SIM)",
+          );
+        } else if (votoPresidente.voto === "NÃO") {
+          resultado = "Reprovada";
+          logger.log(
+            "❌ Resultado: REPROVADA (empate + voto de minerva do presidente: NÃO)",
+          );
+        } else {
+          resultado = "Reprovada";
+          logger.log(
+            "❌ Resultado: REPROVADA (empate + presidente se absteve)",
+          );
+        }
+      } else {
+        resultado = "Reprovada";
+        logger.log("❌ Resultado: REPROVADA (empate + presidente não votou)");
+      }
+    }
+
+    const { error: updateError } = await supabase
+      .from("pautas")
+      .update({
+        resultado_votacao: resultado,
+      })
+      .eq("id", pautaId);
+
+    if (updateError) {
+      logger.error("❌ Erro ao atualizar resultado da votação:", updateError);
+    } else {
+      logger.log(`✅ Resultado da votação atualizado: ${resultado}`);
+    }
+  } catch (error) {
+    logger.error("💥 Erro no cálculo do resultado:", error);
+  }
+};
+
+module.exports = {
+  getAllPautas,
+  getAutoresPautas,
+  getPautaById,
+  createPauta,
+  updateResultadoVotacao,
+  updatePautaStatus,
+  deletePauta,
+  updatePauta,
+};

--- a/src/controllers/publicController.js
+++ b/src/controllers/publicController.js
@@ -1,0 +1,1290 @@
+const supabaseAdmin = require("../config/supabaseAdminClient");
+const createLogger = require("../utils/logger");
+const logger = createLogger("PUBLIC_CONTROLLER");
+
+/**
+ * Public controller actions for camara discovery, public agenda data, voting
+ * results, and vereador statistics.
+ *
+ * @module controllers/publicController
+ */
+
+/**
+ * Lists active camaras for public selection with search and pagination.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getCamarasPublicas = async (req, res) => {
+  const page = parseInt(req.query.page, 10) || 1;
+  const limit = parseInt(req.query.limit, 10) || 8;
+  const search = req.query.search || "";
+  const offset = (page - 1) * limit;
+
+  logger.log(
+    `Buscando câmaras públicas - Página: ${page}, Limite: ${limit}, Busca: ${search}`,
+  );
+
+  try {
+    let countQuery = supabaseAdmin
+      .from("camaras")
+      .select("*", { count: "exact", head: true })
+      .eq("is_active", true);
+
+    if (search) {
+      const searchQuery = `nome_camara.ilike.%${search}%,municipio.ilike.%${search}%`;
+      countQuery = countQuery.or(searchQuery);
+    }
+
+    const { count: totalItems, error: countError } = await countQuery;
+    if (countError) throw countError;
+
+    let query = supabaseAdmin
+      .from("camaras")
+      .select(
+        `
+                id,
+                nome_camara,
+                municipio,
+                estado,
+                brasao_url
+            `,
+      )
+      .eq("is_active", true);
+
+    if (search) {
+      const searchQuery = `nome_camara.ilike.%${search}%,municipio.ilike.%${search}%`;
+      query = query.or(searchQuery);
+    }
+
+    const { data: camaras, error } = await query
+      .order("nome_camara", { ascending: true })
+      .range(offset, offset + limit - 1);
+
+    if (error) throw error;
+
+    const processedCamaras = await Promise.all(
+      camaras.map(async (camara) => {
+        try {
+          const { count: vereadores_count } = await supabaseAdmin
+            .from("vereadores")
+            .select("id", { count: "exact", head: true })
+            .eq("camara_id", camara.id)
+            .eq("is_active", true);
+
+          const { count: sessoes_totais } = await supabaseAdmin
+            .from("sessoes")
+            .select("id", { count: "exact", head: true })
+            .eq("camara_id", camara.id);
+
+          return {
+            id: camara.id,
+            nome_camara: camara.nome_camara,
+            municipio: camara.municipio,
+            estado: camara.estado,
+            brasao_url: camara.brasao_url,
+            vereadores_count: vereadores_count || 0,
+            sessoes_totais: sessoes_totais || 0,
+          };
+        } catch (err) {
+          console.warn(
+            `Erro ao buscar estatísticas da câmara ${camara.id}:`,
+            err.message,
+          );
+          return {
+            id: camara.id,
+            nome_camara: camara.nome_camara,
+            municipio: camara.municipio,
+            estado: camara.estado,
+            brasao_url: camara.brasao_url,
+            vereadores_count: 0,
+            sessoes_totais: 0,
+          };
+        }
+      }),
+    );
+
+    logger.log(
+      `Câmaras encontradas: ${processedCamaras.length} de ${totalItems} total`,
+    );
+
+    res.status(200).json({
+      camaras: processedCamaras,
+      pagination: {
+        total: totalItems,
+        totalPages: Math.ceil(totalItems / limit),
+        currentPage: page,
+        limit,
+        hasNextPage: page < Math.ceil(totalItems / limit),
+        hasPrevPage: page > 1,
+      },
+    });
+  } catch (error) {
+    logger.error("Erro ao buscar câmaras públicas:", error.message);
+    res.status(500).json({
+      error: "Erro ao buscar câmaras",
+      message:
+        "Não foi possível carregar a lista de câmaras. Tente novamente mais tarde.",
+    });
+  }
+};
+
+/**
+ * Retrieves public information and basic statistics for an active camara.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getCamaraPublicInfo = async (req, res) => {
+  const { id } = req.params;
+
+  logger.log(`Buscando informações públicas da câmara: ${id}`);
+
+  try {
+    const { data: camara, error: camaraError } = await supabaseAdmin
+      .from("camaras")
+      .select(
+        `
+                id,
+                nome_camara,
+                municipio,
+                estado,
+                brasao_url,
+                is_active,
+                link_facebook,
+                link_instagram,
+                link_youtube,
+                site_oficial
+            `,
+      )
+      .eq("id", id)
+      .eq("is_active", true)
+      .single();
+
+    if (camaraError || !camara) {
+      return res.status(404).json({
+        error: "Câmara não encontrada",
+        message: "A câmara solicitada não foi encontrada ou não está ativa.",
+      });
+    }
+
+    const [vereadorResult, sessaoResult] = await Promise.all([
+      supabaseAdmin
+        .from("vereadores")
+        .select("id", { count: "exact", head: true })
+        .eq("camara_id", id)
+        .eq("is_active", true),
+
+      supabaseAdmin
+        .from("sessoes")
+        .select("id", { count: "exact", head: true })
+        .eq("camara_id", id)
+        .eq("status", "ativa"),
+    ]);
+
+    let pautasRecentes = 0;
+    try {
+      const { count } = await supabaseAdmin
+        .from("pautas")
+        .select("id", { count: "exact", head: true })
+        .gte(
+          "created_at",
+          new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+        )
+        .in("status", ["Em Votação", "Finalizada"]);
+      pautasRecentes = count || 0;
+    } catch (pautaError) {
+      console.warn("Erro ao buscar pautas recentes:", pautaError.message);
+      pautasRecentes = 0;
+    }
+
+    const responseData = {
+      info: camara,
+      estatisticas: {
+        vereadores_ativos: vereadorResult.count || 0,
+        sessoes_ativas: sessaoResult.count || 0,
+        pautas_recentes: pautasRecentes,
+      },
+    };
+
+    logger.log(`Informações da câmara ${id} carregadas com sucesso`);
+
+    res.status(200).json(responseData);
+  } catch (error) {
+    logger.error(`Erro ao buscar informações da câmara ${id}:`, error.message);
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar as informações da câmara.",
+    });
+  }
+};
+
+/**
+ * Lists upcoming scheduled sessions for an active camara.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getSessoesFuturas = async (req, res) => {
+  const { id } = req.params;
+
+  logger.log(`Buscando sessões futuras da câmara: ${id}`);
+
+  try {
+    const { data: camara } = await supabaseAdmin
+      .from("camaras")
+      .select("id")
+      .eq("id", id)
+      .eq("is_active", true)
+      .single();
+
+    if (!camara) {
+      return res.status(404).json({
+        error: "Câmara não encontrada",
+        message: "A câmara solicitada não foi encontrada ou não está ativa.",
+      });
+    }
+
+    const agora = new Date().toISOString();
+    const { data: sessoes, error } = await supabaseAdmin
+      .from("sessoes")
+      .select(
+        `
+                id,
+                nome,
+                tipo,
+                data_sessao,
+                status
+            `,
+      )
+      .eq("camara_id", id)
+      .gt("data_sessao", agora)
+      .eq("status", "Agendada")
+      .order("data_sessao", { ascending: true })
+      .limit(10);
+
+    if (error) throw error;
+
+    logger.log(`Sessões futuras encontradas: ${sessoes.length}`);
+
+    res.status(200).json({
+      sessoes: sessoes || [],
+      total: sessoes.length,
+    });
+  } catch (error) {
+    logger.error(
+      `Erro ao buscar sessões futuras da câmara ${id}:`,
+      error.message,
+    );
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar as sessões futuras.",
+    });
+  }
+};
+
+/**
+ * Calculates how many finalized agenda items a vereador has voted on.
+ *
+ * @param {string} vereadorId - Vereador identifier.
+ * @param {string} camaraId - Camara identifier.
+ * @returns {Promise<number>} Total finalized agenda votes for the vereador.
+ */
+const calcularVotacoes = async (vereadorId, camaraId) => {
+  try {
+    const { data: sessoes, error: sessoesError } = await supabaseAdmin
+      .from("sessoes")
+      .select("id")
+      .eq("camara_id", camaraId);
+
+    if (sessoesError) {
+      console.warn(
+        `Erro ao buscar sessões para votações:`,
+        sessoesError.message,
+      );
+      return 0;
+    }
+
+    if (!sessoes || sessoes.length === 0) {
+      return 0;
+    }
+
+    const sessaoIds = sessoes.map((s) => s.id);
+
+    const { data: pautas, error: pautasError } = await supabaseAdmin
+      .from("pautas")
+      .select("id")
+      .eq("status", "Finalizada")
+      .in("sessao_id", sessaoIds);
+
+    if (pautasError) {
+      console.warn(`Erro ao buscar pautas finalizadas:`, pautasError.message);
+      return 0;
+    }
+
+    if (!pautas || pautas.length === 0) {
+      return 0;
+    }
+
+    const pautaIds = pautas.map((p) => p.id);
+
+    const { count: totalVotacoes, error: votosError } = await supabaseAdmin
+      .from("votos")
+      .select("id", { count: "exact", head: true })
+      .eq("vereador_id", vereadorId)
+      .in("pauta_id", pautaIds);
+
+    if (votosError) {
+      console.warn(
+        `Erro ao contar votos do vereador ${vereadorId}:`,
+        votosError.message,
+      );
+      return 0;
+    }
+
+    console.log(
+      `Vereador ${vereadorId}: ${totalVotacoes || 0} votações em ${
+        pautas.length
+      } pautas finalizadas`,
+    );
+    return totalVotacoes || 0;
+  } catch (error) {
+    console.warn(
+      `Erro ao calcular votações do vereador ${vereadorId}:`,
+      error.message,
+    );
+    return 0;
+  }
+};
+
+/**
+ * Calculates attendance statistics for a vereador.
+ *
+ * A vereador is considered present in a past session when they voted on at
+ * least one finalized agenda item from that session.
+ *
+ * @param {string} vereadorId - Vereador identifier.
+ * @param {string} camaraId - Camara identifier.
+ * @returns {Promise<object>} Attendance totals and percentage.
+ */
+const calcularPresenca = async (vereadorId, camaraId) => {
+  try {
+    const agora = new Date().toISOString();
+    console.log(`🕐 Data atual para filtro: ${agora}`);
+
+    const { data: sessoes, error: sessoesError } = await supabaseAdmin
+      .from("sessoes")
+      .select("id, nome, data_sessao, status")
+      .eq("camara_id", camaraId)
+      .lt("data_sessao", agora);
+
+    if (sessoesError) {
+      console.warn(
+        `Erro ao buscar sessões para presença:`,
+        sessoesError.message,
+      );
+      return { sessoes_presentes: 0, total_sessoes: 0, percentual: 0 };
+    }
+
+    console.log(
+      `🎯 Sessões não futuras encontradas (${sessoes?.length || 0}):`,
+    );
+    if (sessoes) {
+      sessoes.forEach((s) => {
+        console.log(`  - ${s.nome}: ${s.data_sessao} (${s.status})`);
+      });
+    }
+
+    if (!sessoes || sessoes.length === 0) {
+      console.log(`⚠️ Nenhuma sessão passada encontrada`);
+      return { sessoes_presentes: 0, total_sessoes: 0, percentual: 0 };
+    }
+
+    const totalSessoes = sessoes.length;
+    let sessoesPresentes = 0;
+
+    console.log(
+      `\n📊 Analisando presença em ${totalSessoes} sessões para vereador ${vereadorId}`,
+    );
+
+    for (const sessao of sessoes) {
+      console.log(`\n🔍 Sessão: ${sessao.nome} (${sessao.data_sessao})`);
+
+      const { data: pautasFinalizadas, error: pautasError } =
+        await supabaseAdmin
+          .from("pautas")
+          .select("id, nome, status")
+          .eq("sessao_id", sessao.id)
+          .eq("status", "Finalizada");
+
+      if (pautasError) {
+        console.warn(
+          `❌ Erro ao buscar pautas finalizadas:`,
+          pautasError.message,
+        );
+        continue;
+      }
+
+      console.log(
+        `   📝 Pautas FINALIZADAS: ${pautasFinalizadas?.length || 0}`,
+      );
+      if (pautasFinalizadas && pautasFinalizadas.length > 0) {
+        pautasFinalizadas.forEach((p) => {
+          console.log(`      - ${p.nome} (${p.status})`);
+        });
+      }
+
+      if (!pautasFinalizadas || pautasFinalizadas.length === 0) {
+        console.log(`   ⚠️ Sessão sem pautas finalizadas, vereador ausente`);
+        continue;
+      }
+
+      const pautaIds = pautasFinalizadas.map((p) => p.id);
+
+      const { count: votosEmPautasFinalizadas, error: votosError } =
+        await supabaseAdmin
+          .from("votos")
+          .select("id", { count: "exact", head: true })
+          .eq("vereador_id", vereadorId)
+          .in("pauta_id", pautaIds);
+
+      if (votosError) {
+        console.warn(`❌ Erro ao verificar votos:`, votosError.message);
+        continue;
+      }
+
+      console.log(
+        `   🗳️ Votos em pautas finalizadas: ${votosEmPautasFinalizadas || 0}`,
+      );
+
+      if (votosEmPautasFinalizadas && votosEmPautasFinalizadas > 0) {
+        sessoesPresentes++;
+        console.log(
+          `   ✅ PRESENTE (votou em ${votosEmPautasFinalizadas} pautas finalizadas)`,
+        );
+      } else {
+        console.log(`   ❌ AUSENTE (não votou em nenhuma pauta finalizada)`);
+      }
+    }
+
+    const percentual =
+      totalSessoes > 0
+        ? Math.round((sessoesPresentes / totalSessoes) * 100)
+        : 0;
+
+    console.log(
+      `\n📋 RESULTADO - Vereador ${vereadorId}: ${sessoesPresentes}/${totalSessoes} sessões = ${percentual}%`,
+    );
+
+    return {
+      sessoes_presentes: sessoesPresentes,
+      total_sessoes: totalSessoes,
+      percentual: percentual,
+    };
+  } catch (error) {
+    console.warn(
+      `Erro ao calcular presença do vereador ${vereadorId}:`,
+      error.message,
+    );
+    return { sessoes_presentes: 0, total_sessoes: 0, percentual: 0 };
+  }
+};
+
+/**
+ * Calculates vereador statistics using the fastest available data source.
+ *
+ * Tries the materialized view first, then the RPC function, then the fallback
+ * query implementation.
+ *
+ * @param {string} camaraId - Camara identifier.
+ * @returns {Promise<object>} Map of vereador id to statistics.
+ */
+const calcularEstatisticasOtimizadas = async (camaraId) => {
+  try {
+    console.log(
+      `🚀 Calculando estatísticas otimizadas para câmara: ${camaraId}`,
+    );
+
+    const { data: mvData, error: mvError } = await supabaseAdmin
+      .from("mv_vereador_estatisticas")
+      .select("*")
+      .eq("camara_id", camaraId);
+
+    if (!mvError && mvData && mvData.length > 0) {
+      console.log(`✅ Usando materialized view - ${mvData.length} vereadores`);
+      const statsMap = {};
+      mvData.forEach((stat) => {
+        const percentual =
+          stat.total_sessoes_mandato > 0
+            ? Math.round(
+                (stat.sessoes_presentes / stat.total_sessoes_mandato) * 100,
+              )
+            : 0;
+        statsMap[stat.vereador_id] = {
+          total_votacoes: stat.total_votacoes || 0,
+          percentual_presenca: percentual,
+          sessoes_presentes: stat.sessoes_presentes || 0,
+          total_sessoes: stat.total_sessoes_mandato || 0,
+        };
+      });
+      return statsMap;
+    }
+
+    const agora = new Date().toISOString();
+    const { data: estatisticas, error } = await supabaseAdmin.rpc(
+      "calcular_estatisticas_vereadores",
+      {
+        p_camara_id: camaraId,
+        p_data_atual: agora,
+      },
+    );
+
+    if (!error && estatisticas) {
+      console.log(`✅ Usando RPC - ${estatisticas.length} vereadores`);
+      const statsMap = {};
+      estatisticas.forEach((stat) => {
+        statsMap[stat.vereador_id] = {
+          total_votacoes: stat.total_votacoes || 0,
+          percentual_presenca: stat.percentual_presenca || 0,
+          sessoes_presentes: stat.sessoes_presentes || 0,
+          total_sessoes: stat.total_sessoes || 0,
+        };
+      });
+      return statsMap;
+    }
+
+    console.warn(
+      "Materialized view e RPC indisponíveis, usando consulta alternativa",
+    );
+    return await calcularEstatisticasAlternativa(camaraId);
+  } catch (error) {
+    console.warn("Erro ao calcular estatísticas otimizadas:", error.message);
+    return await calcularEstatisticasAlternativa(camaraId);
+  }
+};
+
+/**
+ * Calculates vereador statistics directly through Supabase queries.
+ *
+ * Sessions are filtered by each vereador's mandate period and only sessions
+ * with finalized agenda items that received votes are counted.
+ *
+ * @param {string} camaraId - Camara identifier.
+ * @returns {Promise<object>} Map of vereador id to statistics.
+ */
+const calcularEstatisticasAlternativa = async (camaraId) => {
+  try {
+    const agora = new Date().toISOString();
+    console.log(`🔄 Usando consulta alternativa para câmara: ${camaraId}`);
+
+    const { data: vereadores } = await supabaseAdmin
+      .from("vereadores")
+      .select("id, created_at, data_saida")
+      .eq("camara_id", camaraId)
+      .eq("is_active", true);
+
+    if (!vereadores || vereadores.length === 0) {
+      return {};
+    }
+
+    const vereadorIds = vereadores.map((v) => v.id);
+
+    const mandatoMap = {};
+    vereadores.forEach((v) => {
+      mandatoMap[v.id] = {
+        inicio: v.created_at,
+        fim: v.data_saida || agora,
+      };
+    });
+
+    const statsMap = {};
+
+    const { data: votacoes } = await supabaseAdmin
+      .from("votos")
+      .select(
+        `
+                vereador_id,
+                pautas!inner (
+                    status,
+                    sessoes!inner (
+                        camara_id
+                    )
+                )
+            `,
+      )
+      .in("vereador_id", vereadorIds)
+      .eq("pautas.status", "Finalizada")
+      .eq("pautas.sessoes.camara_id", camaraId);
+
+    votacoes?.forEach((voto) => {
+      if (!statsMap[voto.vereador_id]) {
+        statsMap[voto.vereador_id] = {
+          total_votacoes: 0,
+          sessoes_presentes: new Set(),
+        };
+      }
+      statsMap[voto.vereador_id].total_votacoes++;
+    });
+
+    const { data: presencas } = await supabaseAdmin
+      .from("votos")
+      .select(
+        `
+                vereador_id,
+                pautas!inner (
+                    status,
+                    sessao_id,
+                    sessoes!inner (
+                        camara_id,
+                        data_sessao
+                    )
+                )
+            `,
+      )
+      .in("vereador_id", vereadorIds)
+      .eq("pautas.status", "Finalizada")
+      .eq("pautas.sessoes.camara_id", camaraId)
+      .lt("pautas.sessoes.data_sessao", agora);
+
+    presencas?.forEach((presenca) => {
+      const vereadorId = presenca.vereador_id;
+      const dataSessao = presenca.pautas.sessoes.data_sessao;
+      const mandato = mandatoMap[vereadorId];
+
+      if (
+        mandato &&
+        dataSessao >= mandato.inicio &&
+        dataSessao <= mandato.fim
+      ) {
+        if (!statsMap[vereadorId]) {
+          statsMap[vereadorId] = {
+            total_votacoes: 0,
+            sessoes_presentes: new Set(),
+          };
+        }
+        statsMap[vereadorId].sessoes_presentes.add(presenca.pautas.sessao_id);
+      }
+    });
+
+    const { data: sessoesComVotos } = await supabaseAdmin
+      .from("sessoes")
+      .select(
+        `
+        id,
+        data_sessao,
+        pautas!inner (
+          id,
+          status,
+          votos!inner (
+            id
+          )
+        )
+      `,
+      )
+      .eq("camara_id", camaraId)
+      .eq("pautas.status", "Finalizada")
+      .lt("data_sessao", agora);
+
+    const sessoesValidasIds = new Set();
+    sessoesComVotos?.forEach((sessao) => {
+      if (
+        sessao.pautas &&
+        sessao.pautas.some((p) => p.votos && p.votos.length > 0)
+      ) {
+        sessoesValidasIds.add(sessao.id);
+      }
+    });
+
+    const sessoesValidasMap = {};
+    sessoesComVotos?.forEach((sessao) => {
+      if (sessoesValidasIds.has(sessao.id)) {
+        sessoesValidasMap[sessao.id] = sessao.data_sessao;
+      }
+    });
+
+    const finalStats = {};
+    vereadores.forEach((vereador) => {
+      const mandato = mandatoMap[vereador.id];
+
+      let sessoesNoMandato = 0;
+      Object.entries(sessoesValidasMap).forEach(([, dataSessao]) => {
+        if (dataSessao >= mandato.inicio && dataSessao <= mandato.fim) {
+          sessoesNoMandato++;
+        }
+      });
+
+      const stats = statsMap[vereador.id] || {
+        total_votacoes: 0,
+        sessoes_presentes: new Set(),
+      };
+      const sessoesPresentes = stats.sessoes_presentes?.size || 0;
+      const percentual =
+        sessoesNoMandato > 0
+          ? Math.round((sessoesPresentes / sessoesNoMandato) * 100)
+          : 0;
+
+      finalStats[vereador.id] = {
+        total_votacoes: stats.total_votacoes || 0,
+        percentual_presenca: percentual,
+        sessoes_presentes: sessoesPresentes,
+        total_sessoes: sessoesNoMandato,
+      };
+    });
+
+    console.log(
+      `✅ Estatísticas alternativas calculadas para ${
+        Object.keys(finalStats).length
+      } vereadores`,
+    );
+    return finalStats;
+  } catch (error) {
+    console.warn("Erro na consulta alternativa:", error.message);
+    return {};
+  }
+};
+
+/**
+ * Lists active vereadores for a camara with party data and calculated statistics.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getVereadores = async (req, res) => {
+  const { id } = req.params;
+
+  logger.log(`Buscando vereadores ativos da câmara: ${id}`);
+
+  try {
+    const { data: camara } = await supabaseAdmin
+      .from("camaras")
+      .select("id")
+      .eq("id", id)
+      .eq("is_active", true)
+      .single();
+
+    if (!camara) {
+      return res.status(404).json({
+        error: "Câmara não encontrada",
+        message: "A câmara solicitada não foi encontrada ou não está ativa.",
+      });
+    }
+
+    const [vereadoresResult, estatisticas] = await Promise.all([
+      supabaseAdmin
+        .from("vereadores")
+        .select(
+          `
+                    id,
+                    nome_parlamentar,
+                    foto_url,
+                    is_presidente,
+                    is_vice_presidente,
+                    partidos!inner (
+                        id,
+                        nome,
+                        sigla,
+                        logo_url
+                    )
+                `,
+        )
+        .eq("camara_id", id)
+        .eq("is_active", true)
+        .order("nome_parlamentar", { ascending: true }),
+      calcularEstatisticasOtimizadas(id),
+    ]);
+
+    if (vereadoresResult.error) throw vereadoresResult.error;
+
+    const vereadoresComEstatisticas = vereadoresResult.data.map((vereador) => {
+      let cargo = "Vereador";
+
+      if (vereador.is_presidente) {
+        cargo = "Presidente da Câmara";
+      } else if (vereador.is_vice_presidente) {
+        cargo = "Vice-Presidente";
+      }
+
+      const stats = estatisticas[vereador.id] || {
+        total_votacoes: 0,
+        percentual_presenca: 0,
+        sessoes_presentes: 0,
+        total_sessoes: 0,
+      };
+
+      return {
+        id: vereador.id,
+        nome: vereador.nome_parlamentar,
+        foto_url: vereador.foto_url,
+        cargo: cargo,
+        partido: {
+          id: vereador.partidos.id,
+          nome: vereador.partidos.nome,
+          sigla: vereador.partidos.sigla,
+          logo_url: vereador.partidos.logo_url,
+        },
+        estatisticas: stats,
+      };
+    });
+
+    logger.log(
+      `Vereadores ativos encontrados: ${vereadoresComEstatisticas.length}`,
+    );
+
+    res.status(200).json({
+      vereadores: vereadoresComEstatisticas,
+      total: vereadoresComEstatisticas.length,
+    });
+  } catch (error) {
+    logger.error(`Erro ao buscar vereadores da câmara ${id}:`, error.message);
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar os vereadores.",
+    });
+  }
+};
+
+/**
+ * Lists the latest finalized votes for an active camara.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getVotacoesRecentes = async (req, res) => {
+  const { id } = req.params;
+
+  logger.log(`Buscando votações recentes da câmara: ${id}`);
+
+  try {
+    const { data: camara } = await supabaseAdmin
+      .from("camaras")
+      .select("id")
+      .eq("id", id)
+      .eq("is_active", true)
+      .single();
+
+    if (!camara) {
+      return res.status(404).json({
+        error: "Câmara não encontrada",
+        message: "A câmara solicitada não foi encontrada ou não está ativa.",
+      });
+    }
+
+    // Prefer updated_at when the schema supports it.
+    let pautas = null;
+    try {
+      const resp = await supabaseAdmin
+        .from("pautas")
+        .select(
+          `
+                    id,
+                    nome,
+                    descricao,
+                    autor,
+                    resultado_votacao,
+                    created_at,
+                    updated_at,
+                    sessoes!inner (
+                        id,
+                        nome,
+                        data_sessao,
+                        camara_id
+                    )
+                `,
+        )
+        .eq("status", "Finalizada")
+        .eq("sessoes.camara_id", id)
+        .order("updated_at", { ascending: false })
+        .limit(9);
+
+      if (resp.error) throw resp.error;
+      pautas = resp.data;
+    } catch (err) {
+      logger.warn(
+        "updated_at não disponível ou erro ao ordenar por updated_at, recuando para created_at:",
+        err.message || err,
+      );
+      const resp2 = await supabaseAdmin
+        .from("pautas")
+        .select(
+          `
+                    id,
+                    nome,
+                    descricao,
+                    autor,
+                    resultado_votacao,
+                    created_at,
+                    sessoes!inner (
+                        id,
+                        nome,
+                        data_sessao,
+                        camara_id
+                    )
+                `,
+        )
+        .eq("status", "Finalizada")
+        .eq("sessoes.camara_id", id)
+        .order("created_at", { ascending: false })
+        .limit(9);
+
+      if (resp2.error) throw resp2.error;
+      pautas = resp2.data;
+    }
+
+    const votacoesFormatadas = pautas.map((pauta) => {
+      let status = "Pendente";
+      let statusClass = "pending";
+
+      if (pauta.resultado_votacao === "Aprovada") {
+        status = "APROVADA";
+        statusClass = "approved";
+      } else if (pauta.resultado_votacao === "Reprovada") {
+        status = "REPROVADA";
+        statusClass = "rejected";
+      } else if (pauta.resultado_votacao === "Não Votada") {
+        status = "NÃO VOTADA";
+        statusClass = "not-voted";
+      }
+
+      return {
+        id: pauta.id,
+        nome: pauta.nome,
+        descricao: pauta.descricao || "Descrição não informada",
+        autor: pauta.autor || "Autor não informado",
+        status: status,
+        statusClass: statusClass,
+        sessao: {
+          nome: pauta.sessoes.nome,
+          data: pauta.sessoes.data_sessao,
+        },
+        data_criacao: pauta.created_at,
+        data_finalizacao: pauta.updated_at,
+      };
+    });
+
+    logger.log(`Votações recentes encontradas: ${votacoesFormatadas.length}`);
+
+    res.status(200).json({
+      pautas: votacoesFormatadas,
+      total: votacoesFormatadas.length,
+    });
+  } catch (error) {
+    logger.error(
+      `Erro ao buscar votações recentes da câmara ${id}:`,
+      error.message,
+    );
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar as votações recentes.",
+    });
+  }
+};
+
+/**
+ * Retrieves public information for a specific agenda item.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getPautaPublica = async (req, res) => {
+  const { id } = req.params;
+
+  logger.log(`Buscando pauta pública: ${id}`);
+
+  try {
+    const { data: pauta, error } = await supabaseAdmin
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                descricao,
+                autor,
+                status,
+                resultado_votacao,
+        created_at,
+        updated_at,
+                sessoes!inner (
+                    id,
+                    nome,
+                    data_sessao,
+                    camaras!inner (
+                        id,
+                        nome_camara,
+                        is_active
+                    )
+                )
+            `,
+      )
+      .eq("id", id)
+      .eq("sessoes.camaras.is_active", true)
+      .single();
+
+    if (error || !pauta) {
+      return res.status(404).json({
+        error: "Pauta não encontrada",
+        message:
+          "A pauta solicitada não foi encontrada ou não está disponível publicamente.",
+      });
+    }
+
+    logger.log(`Pauta pública encontrada: ${pauta.nome}`);
+
+    res.status(200).json(pauta);
+  } catch (error) {
+    logger.error(`Erro ao buscar pauta pública ${id}:`, error.message);
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar as informações da pauta.",
+    });
+  }
+};
+
+/**
+ * Lists public votes for an agenda item with vote totals.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getVotosPublicos = async (req, res) => {
+  const { id } = req.params;
+
+  logger.log(`Buscando votos públicos da pauta: ${id}`);
+
+  try {
+    const { data: pauta } = await supabaseAdmin
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                sessoes!inner (
+                    camaras!inner (
+                        id,
+                        is_active
+                    )
+                )
+            `,
+      )
+      .eq("id", id)
+      .eq("sessoes.camaras.is_active", true)
+      .single();
+
+    if (!pauta) {
+      return res.status(404).json({
+        error: "Pauta não encontrada",
+        message:
+          "A pauta solicitada não foi encontrada ou não está disponível publicamente.",
+      });
+    }
+
+    const { data: votos, error: votosError } = await supabaseAdmin
+      .from("votos")
+      .select(
+        `
+                id,
+                voto,
+                created_at,
+                era_presidente_no_voto,
+                vereadores!inner (
+                    id,
+                    nome_parlamentar,
+                    foto_url,
+                    partidos (
+                        id,
+                        nome,
+                        sigla,
+                        logo_url
+                    )
+                )
+            `,
+      )
+      .eq("pauta_id", id)
+      .order("created_at", { ascending: true });
+
+    if (votosError) throw votosError;
+
+    let estatisticas = {
+      sim: 0,
+      nao: 0,
+      abstencao: 0,
+      total: 0,
+    };
+
+    if (votos && votos.length > 0) {
+      votos.forEach((voto) => {
+        switch (voto.voto) {
+          case "SIM":
+            estatisticas.sim++;
+            break;
+          case "NÃO":
+            estatisticas.nao++;
+            break;
+          case "ABSTENÇÃO":
+            estatisticas.abstencao++;
+            break;
+        }
+      });
+      estatisticas.total = votos.length;
+    }
+
+    logger.log(`Votos públicos encontrados: ${votos?.length || 0}`);
+
+    res.status(200).json({
+      votos: votos || [],
+      estatisticas: estatisticas,
+    });
+  } catch (error) {
+    logger.error(
+      `Erro ao buscar votos públicos da pauta ${id}:`,
+      error.message,
+    );
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar os votos da pauta.",
+    });
+  }
+};
+
+/**
+ * Lists public agenda items for an active camara with pagination.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getAllPautasPublicas = async (req, res) => {
+  const { id } = req.params;
+  const page = parseInt(req.query.page) || 1;
+  const limit = parseInt(req.query.limit) || 12;
+  const offset = (page - 1) * limit;
+
+  logger.log(
+    `Buscando todas as pautas da câmara ${id} - Página: ${page}, Limite: ${limit}`,
+  );
+
+  try {
+    const { data: camara } = await supabaseAdmin
+      .from("camaras")
+      .select("id, nome_camara")
+      .eq("id", id)
+      .eq("is_active", true)
+      .single();
+
+    if (!camara) {
+      return res.status(404).json({
+        error: "Câmara não encontrada",
+        message: "A câmara solicitada não foi encontrada ou não está ativa.",
+      });
+    }
+
+    const { count: totalPautas } = await supabaseAdmin
+      .from("pautas")
+      .select("id, sessoes!inner(camara_id)", { count: "exact", head: true })
+      .eq("sessoes.camara_id", id)
+      .neq("status", "Arquivada");
+
+    const { data: pautas, error: pautasError } = await supabaseAdmin
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                descricao,
+                autor,
+                status,
+                resultado_votacao,
+                created_at,
+                sessoes!inner (
+                    id,
+                    nome,
+                    tipo,
+                    data_sessao,
+                    camara_id
+                )
+            `,
+      )
+      .eq("sessoes.camara_id", id)
+      .neq("status", "Arquivada")
+      .order("created_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (pautasError) throw pautasError;
+
+    const pautasComEstatisticas = await Promise.all(
+      pautas.map(async (pauta) => {
+        if (pauta.status === "Finalizada") {
+          try {
+            const { data: votos } = await supabaseAdmin
+              .from("votos")
+              .select("voto")
+              .eq("pauta_id", pauta.id);
+
+            const estatisticas = {
+              total: votos?.length || 0,
+              sim: votos?.filter((v) => v.voto === "SIM").length || 0,
+              nao: votos?.filter((v) => v.voto === "NÃO").length || 0,
+              abstencao:
+                votos?.filter((v) => v.voto === "ABSTENÇÃO").length || 0,
+            };
+
+            return { ...pauta, estatisticas };
+          } catch (error) {
+            logger.error(
+              `Erro ao buscar estatísticas da pauta ${pauta.id}:`,
+              error,
+            );
+            return pauta;
+          }
+        }
+        return pauta;
+      }),
+    );
+
+    const totalPages = Math.ceil(totalPautas / limit);
+
+    const responseData = {
+      camara: {
+        id: camara.id,
+        nome: camara.nome_camara,
+      },
+      pautas: pautasComEstatisticas,
+      paginacao: {
+        current_page: page,
+        total_pages: totalPages,
+        total_items: totalPautas,
+        items_per_page: limit,
+        has_next: page < totalPages,
+        has_prev: page > 1,
+      },
+    };
+
+    logger.log(
+      `${pautasComEstatisticas.length} pautas encontradas para câmara ${id}`,
+    );
+    res.status(200).json(responseData);
+  } catch (error) {
+    logger.error(`Erro ao buscar pautas da câmara ${id}:`, error.message);
+    res.status(500).json({
+      error: "Erro interno",
+      message: "Não foi possível carregar as pautas da câmara.",
+    });
+  }
+};
+
+module.exports = {
+  getCamarasPublicas,
+  getCamaraPublicInfo,
+  getSessoesFuturas,
+  getVereadores,
+  getVotacoesRecentes,
+  getPautaPublica,
+  getVotosPublicos,
+  getAllPautasPublicas,
+};

--- a/src/controllers/votoController.js
+++ b/src/controllers/votoController.js
@@ -1,0 +1,609 @@
+const { createClient } = require("@supabase/supabase-js");
+const createLogger = require("../utils/logger");
+
+const logger = createLogger("VOTO_CONTROLLER");
+
+/**
+ * Controller actions for recording votes and reading vote totals.
+ *
+ * @module controllers/votoController
+ */
+
+/**
+ * Authenticates a request using its Supabase bearer token and loads vereador
+ * metadata when the profile role is vereador.
+ *
+ * @param {object} req - Express request object.
+ * @returns {Promise<object>} Authenticated user, profile, and optional vereador data.
+ * @throws {Error} When the token is missing, invalid, or the profile cannot be found.
+ */
+const authenticateToken = async (req) => {
+  const authHeader = req.headers["authorization"];
+  const token = authHeader && authHeader.split(" ")[1];
+
+  if (!token) {
+    throw new Error("Token de acesso requerido");
+  }
+
+  try {
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_ANON_KEY,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      logger.error("Erro ao verificar usuário:", userError);
+      throw new Error("Token inválido ou expirado");
+    }
+
+    const supabaseAdmin = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY
+    );
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from("profiles")
+      .select("*, camaras(nome_camara)")
+      .eq("id", user.id)
+      .single();
+
+    if (profileError || !profile) {
+      logger.error("Erro ao buscar perfil:", profileError);
+      throw new Error("Perfil não encontrado");
+    }
+
+    let vereadorData = null;
+    if (profile.role === "vereador") {
+      const { data: vereador, error: vereadorError } = await supabaseAdmin
+        .from("vereadores")
+        .select(
+          "id, nome_parlamentar, is_presidente, is_vice_presidente, partido_id"
+        )
+        .eq("profile_id", user.id)
+        .single();
+
+      if (vereadorError) {
+        logger.error("Erro ao buscar dados do vereador:", vereadorError);
+        throw new Error("Dados do vereador não encontrados");
+      }
+
+      vereadorData = vereador;
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      role: profile.role,
+      camara_id: profile.camara_id,
+      profile: profile,
+      vereador: vereadorData,
+    };
+  } catch (error) {
+    logger.error("Erro na autenticação:", error);
+    throw new Error("Token inválido");
+  }
+};
+
+/**
+ * Creates or updates a vereador vote and emits live voting updates.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const createVoto = async (req, res) => {
+  logger.log("🗳️ === INÍCIO DO REGISTRO DE VOTO ===");
+
+  try {
+    const user = await authenticateToken(req);
+
+    if (user.role !== "vereador") {
+      logger.error(`❌ Acesso negado: Usuário ${user.id} não é vereador`);
+      return res.status(403).json({ error: "Apenas vereadores podem votar" });
+    }
+
+    const { pauta_id, voto } = req.body;
+
+    logger.log("📋 Dados do voto:", {
+      vereador_id: user.vereador.id,
+      pauta_id,
+      voto,
+      is_presidente: user.vereador.is_presidente,
+    });
+
+    if (!pauta_id || !voto) {
+      logger.error("❌ Dados obrigatórios não fornecidos");
+      return res
+        .status(400)
+        .json({ error: "Pauta ID e voto são obrigatórios" });
+    }
+
+    let votoEnum;
+    switch (voto) {
+      case "Sim":
+        votoEnum = "SIM";
+        break;
+      case "Não":
+        votoEnum = "NÃO";
+        break;
+      case "Abstenção":
+        votoEnum = "ABSTENÇÃO";
+        break;
+      default:
+        logger.error("❌ Voto inválido:", voto);
+        return res.status(400).json({
+          error: "Voto inválido. Permitidos: Sim, Não, Abstenção",
+        });
+    }
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY
+    );
+
+    const { data: pauta, error: pautaError } = await supabase
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                status,
+                sessoes!inner (
+                    id,
+                    camara_id
+                )
+            `
+      )
+      .eq("id", pauta_id)
+      .single();
+
+    if (pautaError || !pauta) {
+      logger.error("❌ Pauta não encontrada:", pautaError);
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    if (pauta.status !== "Em Votação") {
+      logger.error("❌ Pauta não está em votação:", pauta.status);
+      return res.status(400).json({ error: "Esta pauta não está em votação" });
+    }
+
+    if (pauta.sessoes.camara_id !== user.camara_id) {
+      logger.error("❌ Pauta de outra câmara");
+      return res
+        .status(403)
+        .json({ error: "Você só pode votar em pautas da sua câmara" });
+    }
+
+    const { data: votoExistente, error: votoExistenteError } = await supabase
+      .from("votos")
+      .select("id, voto")
+      .eq("pauta_id", pauta_id)
+      .eq("vereador_id", user.vereador.id)
+      .single();
+
+    if (votoExistente) {
+      logger.log("🔄 Atualizando voto existente");
+
+      const { data: votoAtualizado, error: updateError } = await supabase
+        .from("votos")
+        .update({
+          voto: votoEnum,
+          era_presidente_no_voto: user.vereador.is_presidente,
+          era_vice_presidente_no_voto: user.vereador.is_vice_presidente,
+          partido_id_no_voto: user.vereador.partido_id,
+        })
+        .eq("id", votoExistente.id)
+        .select()
+        .single();
+
+      if (updateError) {
+        logger.error("❌ Erro ao atualizar voto:", updateError);
+        return res.status(500).json({ error: "Erro ao atualizar voto" });
+      }
+
+      logger.log("✅ Voto atualizado com sucesso");
+      try {
+        if (typeof global !== "undefined" && global.io) {
+          const { data: votosAtualizados } = await supabase
+            .from("votos")
+            .select("voto")
+            .eq("pauta_id", pauta_id);
+
+          const totals = { sim: 0, nao: 0, abstencao: 0 };
+          if (votosAtualizados) {
+            votosAtualizados.forEach((v) => {
+              if (v.voto === "SIM") totals.sim++;
+              else if (v.voto === "NÃO") totals.nao++;
+              else if (v.voto === "ABSTENÇÃO") totals.abstencao++;
+            });
+          }
+
+          const payloadVotacao = {
+            pautaId: pauta_id,
+            totals,
+            voto: votoAtualizado,
+          };
+
+          const camaraId = pauta.sessoes.camara_id;
+          logger.log(`📡 Emitindo voto ATUALIZADO para salas da câmara ${camaraId}`);
+          logger.log(`   - tv-camara-${camaraId}`);
+          logger.log(`   - portal-camara-${camaraId}`);
+          logger.log(`   - painel-camara-${camaraId}`);
+          logger.log(`   Payload:`, JSON.stringify(payloadVotacao));
+
+          global.io
+            .to(`tv-camara-${camaraId}`)
+            .emit("votacao-ao-vivo-update", payloadVotacao);
+
+          global.io
+            .to(`portal-camara-${camaraId}`)
+            .emit("votacao-ao-vivo-update", payloadVotacao);
+
+          global.io
+            .to(`painel-camara-${camaraId}`)
+            .emit("votacao-ao-vivo-update", payloadVotacao);
+
+          logger.log(`✅ Voto ATUALIZADO emitido para TV, Portal e Painel - Câmara ${camaraId} | Totais: SIM=${totals.sim}, NÃO=${totals.nao}, ABSTENÇÃO=${totals.abstencao}`);
+        }
+      } catch (emitErr) {
+        logger.warn(
+          "⚠️ Falha ao emitir socket de update de voto:",
+          emitErr.message
+        );
+      }
+
+      try {
+        const http = require("http");
+        const postData = JSON.stringify({
+          pautaId: pauta_id,
+          voto: votoAtualizado,
+        });
+        const options = {
+          hostname: "localhost",
+          port: 3003,
+          path: "/api/notify/voto",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(postData),
+          },
+        };
+        const r = http.request(options, (resp) => {
+          if (resp.statusCode < 200 || resp.statusCode >= 300)
+            logger.warn(
+              "⚠️ Tablet backend notify voto retornou",
+              resp.statusCode
+            );
+        });
+        r.on("error", (e) =>
+          logger.warn(
+            "⚠️ Erro ao notificar tablet backend sobre voto:",
+            e.message
+          )
+        );
+        r.write(postData);
+        r.end();
+      } catch (err) {
+        logger.warn("⚠️ Erro no post para tablet backend:", err.message);
+      }
+
+      return res.json({
+        message: "Voto atualizado com sucesso",
+        voto: votoAtualizado,
+      });
+    } else {
+      logger.log("🆕 Criando novo voto");
+
+      const { data: novoVoto, error: createError } = await supabase
+        .from("votos")
+        .insert({
+          pauta_id,
+          vereador_id: user.vereador.id,
+          voto: votoEnum,
+          era_presidente_no_voto: user.vereador.is_presidente,
+          era_vice_presidente_no_voto: user.vereador.is_vice_presidente,
+          partido_id_no_voto: user.vereador.partido_id,
+        })
+        .select()
+        .single();
+
+      if (createError) {
+        logger.error("❌ Erro ao criar voto:", createError);
+        return res.status(500).json({ error: "Erro ao registrar voto" });
+      }
+
+      try {
+        if (typeof global !== "undefined" && global.io) {
+          const { data: votosAtualizados } = await supabase
+            .from("votos")
+            .select("voto")
+            .eq("pauta_id", pauta_id);
+
+          const totals = { sim: 0, nao: 0, abstencao: 0 };
+          if (votosAtualizados) {
+            votosAtualizados.forEach((v) => {
+              if (v.voto === "SIM") totals.sim++;
+              else if (v.voto === "NÃO") totals.nao++;
+              else if (v.voto === "ABSTENÇÃO") totals.abstencao++;
+            });
+          }
+
+          const payloadVotacao = {
+            pautaId: pauta_id,
+            totals,
+            voto: novoVoto,
+          };
+
+          const camaraId = pauta.sessoes.camara_id;
+          logger.log(`📡 Emitindo voto para salas da câmara ${camaraId}`);
+          logger.log(`   - tv-camara-${camaraId}`);
+          logger.log(`   - portal-camara-${camaraId}`);
+          logger.log(`   - painel-camara-${camaraId}`);
+          logger.log(`   Payload:`, JSON.stringify(payloadVotacao));
+
+          global.io
+            .to(`tv-camara-${camaraId}`)
+            .emit("votacao-ao-vivo-update", payloadVotacao);
+
+          global.io
+            .to(`portal-camara-${camaraId}`)
+            .emit("votacao-ao-vivo-update", payloadVotacao);
+
+          global.io
+            .to(`painel-camara-${camaraId}`)
+            .emit("votacao-ao-vivo-update", payloadVotacao);
+
+          logger.log(`✅ Voto NOVO emitido para TV, Portal e Painel - Câmara ${camaraId} | Totais: SIM=${totals.sim}, NÃO=${totals.nao}, ABSTENÇÃO=${totals.abstencao}`);
+        }
+      } catch (emitErr) {
+        logger.warn("⚠️ Falha ao emitir socket de novo voto:", emitErr.message);
+      }
+
+      try {
+        const http = require("http");
+        const postData = JSON.stringify({ pautaId: pauta_id, voto: novoVoto });
+        const options = {
+          hostname: "localhost",
+          port: 3003,
+          path: "/api/notify/voto",
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(postData),
+          },
+        };
+        const r = http.request(options, (resp) => {
+          if (resp.statusCode < 200 || resp.statusCode >= 300)
+            logger.warn(
+              "⚠️ Tablet backend notify voto retornou",
+              resp.statusCode
+            );
+        });
+        r.on("error", (e) =>
+          logger.warn(
+            "⚠️ Erro ao notificar tablet backend sobre voto:",
+            e.message
+          )
+        );
+        r.write(postData);
+        r.end();
+      } catch (err) {
+        logger.warn("⚠️ Erro no post para tablet backend:", err.message);
+      }
+
+      logger.log("✅ Voto registrado com sucesso");
+      return res
+        .status(201)
+        .json({ message: "Voto registrado com sucesso", voto: novoVoto });
+    }
+  } catch (error) {
+    logger.error("💥 Erro no registro de voto:", error);
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Token inválido" ||
+      error.message.includes("não encontrado")
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Lists votes for an agenda item with vereador, party, and aggregate statistics.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getVotosPorPauta = async (req, res) => {
+  try {
+    const user = await authenticateToken(req);
+    const { pauta_id } = req.params;
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY
+    );
+
+    const { data: pauta, error: pautaError } = await supabase
+      .from("pautas")
+      .select(
+        `
+                id,
+                nome,
+                status,
+                sessoes!inner (camara_id)
+            `
+      )
+      .eq("id", pauta_id)
+      .single();
+
+    if (pautaError || !pauta) {
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    if (
+      (user.role === "admin_camara" || user.role === "vereador") &&
+      user.camara_id &&
+      pauta.sessoes.camara_id !== user.camara_id
+    ) {
+      return res.status(403).json({ error: "Acesso negado" });
+    }
+
+    const { data: votos, error: votosError } = await supabase
+      .from("votos")
+      .select(
+        `
+                id,
+                voto,
+                created_at,
+                era_presidente_no_voto,
+                era_vice_presidente_no_voto,
+                vereadores (
+                    id,
+                    nome_parlamentar,
+                    foto_url,
+                    partidos (
+                        id,
+                        nome,
+                        sigla,
+                        logo_url
+                    )
+                )
+            `
+      )
+      .eq("pauta_id", pauta_id)
+      .order("created_at", { ascending: true });
+
+    if (votosError) {
+      logger.error("Erro ao buscar votos:", votosError);
+      return res.status(500).json({ error: "Erro ao buscar votos" });
+    }
+
+    const stats = {
+      total: votos.length,
+      sim: votos.filter((v) => v.voto === "SIM").length,
+      nao: votos.filter((v) => v.voto === "NÃO").length,
+      abstencao: votos.filter((v) => v.voto === "ABSTENÇÃO").length,
+      voto_presidente:
+        votos.find((v) => v.era_presidente_no_voto)?.voto || null,
+    };
+
+    res.json({
+      pauta: {
+        id: pauta.id,
+        nome: pauta.nome,
+        status: pauta.status,
+      },
+      votos,
+      estatisticas: stats,
+    });
+  } catch (error) {
+    logger.error("Erro ao buscar votos:", error);
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Token inválido" ||
+      error.message.includes("não encontrado")
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * Returns vote totals for an agenda item visible to the authenticated user.
+ *
+ * @param {object} req - Express request object.
+ * @param {object} res - Express response object.
+ * @returns {Promise<void>}
+ */
+const getVotosTotals = async (req, res) => {
+  try {
+    const { pauta_id } = req.params;
+
+    const user = await authenticateToken(req);
+
+    const supabase = createClient(
+      process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_KEY
+    );
+
+    const { data: pauta, error: pautaError } = await supabase
+      .from("pautas")
+      .select("id, nome, sessoes(camara_id)")
+      .eq("id", pauta_id)
+      .single();
+
+    if (pautaError || !pauta) {
+      return res.status(404).json({ error: "Pauta não encontrada" });
+    }
+
+    if (String(pauta.sessoes.camara_id) !== String(user.camara_id)) {
+      return res.status(403).json({ error: "Acesso negado" });
+    }
+
+    const { data: votos, error: votosError } = await supabase
+      .from("votos")
+      .select("voto")
+      .eq("pauta_id", pauta_id);
+
+    if (votosError) {
+      logger.error("Erro ao buscar votos:", votosError);
+      return res.status(500).json({ error: "Erro ao buscar totais de votos" });
+    }
+
+    const totals = {
+      sim: 0,
+      nao: 0,
+      abstencao: 0,
+    };
+
+    if (votos) {
+      votos.forEach((v) => {
+        if (v.voto === "SIM") totals.sim++;
+        else if (v.voto === "NÃO") totals.nao++;
+        else if (v.voto === "ABSTENÇÃO") totals.abstencao++;
+      });
+    }
+
+    logger.log(`📊 Totais pauta ${pauta_id}: SIM=${totals.sim}, NÃO=${totals.nao}, ABSTENÇÃO=${totals.abstencao}`);
+
+    res.json(totals);
+  } catch (error) {
+    logger.error("Erro ao obter totais de votos:", error);
+
+    if (error.message === "Token de acesso requerido") {
+      return res.status(401).json({ error: error.message });
+    }
+    if (
+      error.message === "Token inválido" ||
+      error.message.includes("não encontrado")
+    ) {
+      return res.status(401).json({ error: error.message });
+    }
+
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+module.exports = {
+  createVoto,
+  getVotosPorPauta,
+  getVotosTotals,
+};

--- a/src/routes/pautas.js
+++ b/src/routes/pautas.js
@@ -1,0 +1,43 @@
+const express = require("express");
+const router = express.Router();
+const pautaController = require("../controllers/pautaController");
+const { uploadSingle } = require("../middleware/uploadMiddleware");
+const { canManagePautas } = require("../middleware/authMiddleware");
+
+/**
+ * Protected agenda routes for listing, creating, updating, and deleting pautas.
+ *
+ * @module routes/pautas
+ */
+
+router.get("/", canManagePautas, pautaController.getAllPautas);
+
+router.get("/autores", canManagePautas, pautaController.getAutoresPautas);
+
+router.post(
+  "/",
+  canManagePautas,
+  uploadSingle("arquivo"),
+  pautaController.createPauta
+);
+
+router.get("/:id", canManagePautas, pautaController.getPautaById);
+
+router.put("/:id/status", canManagePautas, pautaController.updatePautaStatus);
+
+router.put(
+  "/:id/resultado",
+  canManagePautas,
+  pautaController.updateResultadoVotacao
+);
+
+router.put(
+  "/:id",
+  canManagePautas,
+  uploadSingle("arquivo"),
+  pautaController.updatePauta
+);
+
+router.delete("/:id", canManagePautas, pautaController.deletePauta);
+
+module.exports = router;

--- a/src/routes/public.js
+++ b/src/routes/public.js
@@ -1,0 +1,78 @@
+const express = require("express");
+const router = express.Router();
+const publicController = require("../controllers/publicController");
+const authController = require("../controllers/authController");
+
+/**
+ * Public portal routes and token-backed user profile lookup.
+ *
+ * @module routes/public
+ */
+
+/**
+ * @route   GET /api/camaras/publicas
+ * @desc    List active camaras for public selection.
+ * @access  Public
+ */
+router.get("/camaras/publicas", publicController.getCamarasPublicas);
+
+/**
+ * @route   GET /api/camaras/:id/info
+ * @desc    Get public information for a specific camara.
+ * @access  Public
+ */
+router.get("/camaras/:id/info", publicController.getCamaraPublicInfo);
+
+/**
+ * @route   GET /api/camaras/:id/sessoes-futuras
+ * @desc    List upcoming sessions for a specific camara.
+ * @access  Public
+ */
+router.get("/camaras/:id/sessoes-futuras", publicController.getSessoesFuturas);
+
+/**
+ * @route   GET /api/camaras/:id/vereadores
+ * @desc    List active vereadores for a specific camara with party data.
+ * @access  Public
+ */
+router.get("/camaras/:id/vereadores", publicController.getVereadores);
+
+/**
+ * @route   GET /api/camaras/:id/votacoes-recentes
+ * @desc    List recent finalized votes for a specific camara.
+ * @access  Public
+ */
+router.get(
+  "/camaras/:id/votacoes-recentes",
+  publicController.getVotacoesRecentes
+);
+
+/**
+ * @route   GET /api/pautas/:id/publica
+ * @desc    Get public information for a specific pauta.
+ * @access  Public
+ */
+router.get("/pautas/:id/publica", publicController.getPautaPublica);
+
+/**
+ * @route   GET /api/votos/pauta/:id/publico
+ * @desc    List public votes for a specific pauta.
+ * @access  Public
+ */
+router.get("/votos/pauta/:id/publico", publicController.getVotosPublicos);
+
+/**
+ * @route   GET /api/camaras/:id/todas-pautas
+ * @desc    List all public pautas for a specific camara with pagination.
+ * @access  Public
+ */
+router.get("/camaras/:id/todas-pautas", publicController.getAllPautasPublicas);
+
+/**
+ * @route   GET /api/me
+ * @desc    Get authenticated user, profile, and camara information.
+ * @access  Protected via bearer token handled inside the controller.
+ */
+router.get("/me", authController.getMe);
+
+module.exports = router;

--- a/src/routes/votos.js
+++ b/src/routes/votos.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const votoController = require('../controllers/votoController');
+
+/**
+ * Vote routes for creating votes and reading agenda vote data.
+ *
+ * @module routes/votos
+ */
+
+router.post('/', votoController.createVoto);
+
+router.get('/pauta/:pauta_id', votoController.getVotosPorPauta);
+
+router.get('/pauta/:pauta_id/totals', votoController.getVotosTotals);
+
+module.exports = router;


### PR DESCRIPTION
This PR introduces the backend structure for pauta management, vote processing,
and public-facing endpoints used by the voter portal.

Changes

Controllers
- Added pauta CRUD controllers
- Added vote processing and vote history controllers
- Added public API controllers isolated from the admin flow
- Added temporary mocked WebSocket emissions for pauta operations

Routes
- Added pauta routes
- Added voto routes
- Added public API routes

Files Added

Controllers
- `src/controllers/pautaController.js`
- `src/controllers/votoController.js`
- `src/controllers/publicController.js`

Routes
- `src/routes/pautas.js`
- `src/routes/votos.js`
- `src/routes/public.js`

