### PR TITLE
feat(web-backend): add livestream and tv controllers

### DIFF
--- a/src/controllers/falaAoVivoController.js
+++ b/src/controllers/falaAoVivoController.js
@@ -1,0 +1,191 @@
+const createLogger = require("../utils/logger");
+const logger = createLogger("FALA_AO_VIVO");
+
+const {
+  STATUS,
+  getActiveHistoricoByCamara,
+  ensureTempoEsgotadoIfNeeded,
+  getOradorByIdForCamara,
+  marcarTempoEsgotado,
+  toPublicPayload,
+  emitFalaUpdate,
+} = require("../services/falaHistoricoService");
+
+/**
+ * Normalizes chamber identifiers for route and payload comparisons.
+ *
+ * @param {string|number|null|undefined} camaraId - Chamber identifier.
+ * @returns {string} String identifier, or an empty string when missing.
+ */
+function normalizeCamaraId(camaraId) {
+  return camaraId != null ? String(camaraId) : "";
+}
+
+/**
+ * Emits a live-speaking update using the legacy notification contract.
+ *
+ * The current primary flow stores live-speaking state in the database; this
+ * helper keeps the previous function signature available for callers that only
+ * need to broadcast an update.
+ *
+ * @param {import("express").Application} app - Express application instance.
+ * @param {Object} payload - Live-speaking payload received from the caller.
+ * @returns {{stored: boolean, emitted: boolean}} Compatibility status flags.
+ */
+function upsertAndEmitFalaAoVivo(app, payload) {
+  try {
+    const camaraIdStr = normalizeCamaraId(payload?.camaraId);
+    if (!camaraIdStr) return { stored: false, emitted: false };
+
+    // Preserve legacy behavior: emit the update without persisting it.
+    emitFalaUpdate(app, {
+      type: "fala-ao-vivo",
+      historicoFalaId: payload?.historicoFalaId || null,
+      camaraId: camaraIdStr,
+      oradorId: payload?.oradorId != null ? String(payload.oradorId) : null,
+      vereadorId: payload?.vereadorId != null ? String(payload.vereadorId) : null,
+      sessaoId: payload?.sessaoId != null ? String(payload.sessaoId) : null,
+      oradorNome: payload?.oradorNome || null,
+      oradorFotoUrl: payload?.oradorFotoUrl || null,
+      partidoSigla: payload?.partidoSigla || null,
+      status: payload?.status || STATUS.PREPARADA,
+      tempoFalaMinutos: Number.isFinite(Number(payload?.tempoFalaMinutos))
+        ? Number(payload.tempoFalaMinutos)
+        : 0,
+      tempoRestanteSegundos: Number.isFinite(Number(payload?.tempoRestanteSegundos))
+        ? Math.max(0, Math.trunc(Number(payload.tempoRestanteSegundos)))
+        : null,
+      preparadaEm: payload?.preparadaEm || payload?.timestamp || null,
+      iniciadaEm: payload?.startedAt || null,
+      encerradaEm: payload?.endedAt || null,
+      updatedAt: payload?.timestamp || new Date().toISOString(),
+      serverTime: new Date().toISOString(),
+    });
+
+    return { stored: true, emitted: true };
+  } catch (e) {
+    logger.error("Erro ao emitir fala (compat):", e);
+    return { stored: false, emitted: false };
+  }
+}
+
+/**
+ * POST /api/fala-ao-vivo/notify
+ *
+ * Receives live-speaking updates and broadcasts them to chamber TV clients.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const notifyFalaAoVivo = async (req, res) => {
+  try {
+    upsertAndEmitFalaAoVivo(req.app, req.body);
+    res.status(200).json({
+      success: true,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    logger.error("❌ Erro ao processar notificação de fala ao vivo:", error);
+    res.status(500).json({
+      success: false,
+      error: "Erro interno do servidor",
+      timestamp: new Date().toISOString(),
+    });
+  }
+};
+
+/**
+ * GET /api/fala-ao-vivo/status/:camaraId
+ *
+ * Returns the current live-speaking status for a chamber and reconciles expired
+ * speaking time when no in-memory timer is available.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const getStatusFala = async (req, res) => {
+  try {
+    const camaraIdStr = normalizeCamaraId(req.params.camaraId);
+    if (!camaraIdStr) {
+      return res.json({
+        isLive: false,
+        fala: null,
+        message: "Câmara inválida",
+      });
+    }
+
+    const historico = await getActiveHistoricoByCamara(camaraIdStr);
+    if (!historico) {
+      return res.json({
+        isLive: false,
+        fala: null,
+        message: "Nenhuma fala ativa no momento",
+      });
+    }
+
+    let orador = null;
+    try {
+      if (historico.orador_id) {
+        orador = await getOradorByIdForCamara(historico.orador_id, camaraIdStr);
+      }
+    } catch (_) {
+      // Status responses should still succeed when speaker enrichment fails.
+    }
+
+    // Mark expired speaking time after restarts or when no in-memory timer exists.
+    const historicoAtualizado = await ensureTempoEsgotadoIfNeeded(
+      req.app,
+      historico,
+      orador
+    );
+
+    const payload = toPublicPayload(historicoAtualizado, orador);
+
+    return res.json({
+      isLive: historicoAtualizado.status !== STATUS.ENCERRADA,
+      fala: payload,
+    });
+  } catch (error) {
+    logger.error("Erro ao buscar status de fala:", error);
+    res.status(500).json({ error: "Erro interno do servidor" });
+  }
+};
+
+/**
+ * POST /api/fala-ao-vivo/tempo-esgotado/:historicoId
+ *
+ * Idempotently marks a speaking turn as tempo_esgotado without ending it.
+ * Requires authenticated TV or admin access.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const markTempoEsgotado = async (req, res) => {
+  try {
+    const { profile } = req;
+    const { historicoId } = req.params;
+
+    const result = await marcarTempoEsgotado({
+      app: req.app,
+      camaraId: profile.camara_id,
+      historicoId,
+    });
+
+    return res.json({ success: true, fala: result.payload });
+  } catch (error) {
+    logger.error("Erro ao marcar tempo esgotado:", error);
+    return res
+      .status(error.statusCode || 500)
+      .json({ success: false, error: error.message || "Erro interno" });
+  }
+};
+
+module.exports = {
+  notifyFalaAoVivo,
+  getStatusFala,
+  markTempoEsgotado,
+  upsertAndEmitFalaAoVivo,
+};

--- a/src/controllers/livestreamController.js
+++ b/src/controllers/livestreamController.js
@@ -1,0 +1,306 @@
+/**
+ * Livestream Controller
+ *
+ * Express handlers for querying chamber livestreams and triggering manual
+ * livestream checks.
+ */
+
+const livestreamService = require('../services/livestreamService');
+const youtubeService = require('../services/youtubeService');
+
+const logger = {
+    log: (...args) => console.log('[LIVESTREAM_CONTROLLER]', new Date().toISOString(), '-', ...args),
+    error: (...args) => console.error('[LIVESTREAM_CONTROLLER ERROR]', new Date().toISOString(), '-', ...args)
+};
+
+/**
+ * GET /api/livestreams/camara/:camaraId/current
+ *
+ * Returns the currently active livestream for a chamber.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const getCurrentLivestream = async (req, res) => {
+    const { camaraId } = req.params;
+
+    try {
+        logger.log(`Buscando livestream atual da câmara: ${camaraId}`);
+
+        const currentLivestream = await livestreamService.getCurrentLivestream(camaraId);
+
+        if (!currentLivestream) {
+            return res.status(404).json({
+                message: 'Nenhuma livestream ativa encontrada',
+                data: null
+            });
+        }
+
+        logger.log(`Livestream atual encontrada: ${currentLivestream.title}`);
+
+        res.json({
+            message: 'Livestream atual encontrada',
+            data: currentLivestream
+        });
+
+    } catch (error) {
+        logger.error('Erro ao buscar livestream atual:', error.message);
+        res.status(500).json({
+            error: 'Erro interno do servidor',
+            message: error.message
+        });
+    }
+};
+
+/**
+ * GET /api/livestreams/camara/:camaraId/last
+ *
+ * Returns the most recent finished livestream for a chamber.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const getLastLivestream = async (req, res) => {
+    const { camaraId } = req.params;
+
+    try {
+        logger.log(`Buscando última livestream da câmara: ${camaraId}`);
+
+        const lastLivestream = await livestreamService.getLastLivestream(camaraId);
+
+        if (!lastLivestream) {
+            return res.status(404).json({
+                message: 'Nenhuma livestream finalizada encontrada',
+                data: null
+            });
+        }
+
+        logger.log(`Última livestream encontrada: ${lastLivestream.title}`);
+
+        res.json({
+            message: 'Última livestream encontrada',
+            data: lastLivestream
+        });
+
+    } catch (error) {
+        logger.error('Erro ao buscar última livestream:', error.message);
+        res.status(500).json({
+            error: 'Erro interno do servidor',
+            message: error.message
+        });
+    }
+};
+
+/**
+ * GET /api/livestreams/camara/:camaraId
+ *
+ * Lists chamber livestreams with pagination and optional status filtering.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const getCamaraLivestreams = async (req, res) => {
+    const { camaraId } = req.params;
+    const {
+        page = 1,
+        limit = 10,
+        status = null
+    } = req.query;
+
+    try {
+        logger.log(`Listando livestreams da câmara: ${camaraId} (página ${page})`);
+
+        const result = await livestreamService.getCamaraLivestreams(camaraId, {
+            page: parseInt(page),
+            limit: parseInt(limit),
+            status
+        });
+
+        logger.log(`Encontradas ${result.data.length} livestreams (total: ${result.pagination.total})`);
+
+        res.json({
+            message: 'Livestreams encontradas',
+            data: result.data,
+            pagination: result.pagination
+        });
+
+    } catch (error) {
+        logger.error('Erro ao listar livestreams:', error.message);
+        res.status(500).json({
+            error: 'Erro interno do servidor',
+            message: error.message
+        });
+    }
+};
+
+/**
+ * GET /api/livestreams/camara/:camaraId/display
+ *
+ * Returns the active livestream for portal display, falling back to the most
+ * recent livestream when no live stream is active.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const getDisplayLivestream = async (req, res) => {
+    const { camaraId } = req.params;
+
+    try {
+        logger.log(`Buscando livestream para exibição da câmara: ${camaraId}`);
+
+        let livestream = await livestreamService.getCurrentLivestream(camaraId);
+        let isLive = true;
+
+        if (!livestream) {
+            livestream = await livestreamService.getLastLivestream(camaraId);
+            isLive = false;
+        }
+
+        if (!livestream) {
+            return res.status(404).json({
+                message: 'Nenhuma livestream encontrada para exibição',
+                data: null,
+                isLive: false
+            });
+        }
+
+        logger.log(`Livestream para exibição: ${livestream.title} (${isLive ? 'AO VIVO' : 'ÚLTIMA'})`);
+
+        res.json({
+            message: `Livestream ${isLive ? 'ao vivo' : 'mais recente'} encontrada`,
+            data: livestream,
+            isLive
+        });
+
+    } catch (error) {
+        logger.error('Erro ao buscar livestream para exibição:', error.message);
+        res.status(500).json({
+            error: 'Erro interno do servidor',
+            message: error.message
+        });
+    }
+};
+
+/**
+ * POST /api/livestreams/camara/:camaraId/check
+ *
+ * Forces an immediate livestream check for a chamber with a configured YouTube
+ * channel ID.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const forceCheckCamara = async (req, res) => {
+    const { camaraId } = req.params;
+
+    try {
+        logger.log(`Forçando verificação da câmara: ${camaraId}`);
+
+        const supabaseAdmin = require('../config/supabaseAdminClient');
+        const { data: camara, error } = await supabaseAdmin
+            .from('camaras')
+            .select('id, nome_camara, youtube_channel_id')
+            .eq('id', camaraId)
+            .single();
+
+        if (error || !camara) {
+            return res.status(404).json({
+                error: 'Câmara não encontrada',
+                message: 'ID da câmara inválido ou não existe'
+            });
+        }
+
+        if (!camara.youtube_channel_id) {
+            return res.status(400).json({
+                error: 'Câmara não configurada',
+                message: 'Câmara não possui Channel ID do YouTube configurado'
+            });
+        }
+
+        await livestreamService.checkCamaraLivestreams(camara.id, camara.youtube_channel_id);
+
+        logger.log(`Verificação forçada concluída para: ${camara.nome_camara}`);
+
+        res.json({
+            message: 'Verificação de livestreams executada com sucesso',
+            camara: {
+                id: camara.id,
+                nome: camara.nome_camara
+            }
+        });
+
+    } catch (error) {
+        logger.error('Erro na verificação forçada:', error.message);
+        res.status(500).json({
+            error: 'Erro interno do servidor',
+            message: error.message
+        });
+    }
+};
+
+/**
+ * GET /api/livestreams/status
+ *
+ * Returns livestream system health, YouTube API connectivity, and aggregate
+ * livestream counts.
+ *
+ * @param {import("express").Request} req - Express request.
+ * @param {import("express").Response} res - Express response.
+ * @returns {Promise<void>}
+ */
+const getSystemStatus = async (req, res) => {
+    try {
+        logger.log('Verificando status do sistema de livestreams');
+
+        const youtubeConnected = await youtubeService.testConnection();
+
+        const supabaseAdmin = require('../config/supabaseAdminClient');
+
+        const { count: totalCamaras } = await supabaseAdmin
+            .from('camaras')
+            .select('id', { count: 'exact', head: true })
+            .not('youtube_channel_id', 'is', null)
+            .neq('youtube_channel_id', '');
+
+        const { count: activeLivestreams } = await supabaseAdmin
+            .from('livestreams')
+            .select('id', { count: 'exact', head: true })
+            .eq('status', 'live');
+
+        const { count: totalLivestreams } = await supabaseAdmin
+            .from('livestreams')
+            .select('id', { count: 'exact', head: true });
+
+        res.json({
+            message: 'Status do sistema de livestreams',
+            data: {
+                youtube_api_connected: youtubeConnected,
+                cameras_configured: totalCamaras || 0,
+                active_livestreams: activeLivestreams || 0,
+                total_livestreams: totalLivestreams || 0,
+                last_check: new Date().toISOString()
+            }
+        });
+
+    } catch (error) {
+        logger.error('Erro ao verificar status do sistema:', error.message);
+        res.status(500).json({
+            error: 'Erro interno do servidor',
+            message: error.message
+        });
+    }
+};
+
+module.exports = {
+    getCurrentLivestream,
+    getLastLivestream,
+    getCamaraLivestreams,
+    getDisplayLivestream,
+    forceCheckCamara,
+    getSystemStatus
+};

--- a/src/routes/falaAoVivo.js
+++ b/src/routes/falaAoVivo.js
@@ -1,0 +1,22 @@
+const express = require("express");
+const router = express.Router();
+const falaAoVivoController = require("../controllers/falaAoVivoController");
+const { hasPermission } = require("../middleware/authMiddleware");
+
+/**
+ * Live-speaking routes for public status, TV notifications, and protected
+ * timeout updates.
+ */
+const canMarkTempoEsgotado = hasPermission(["tv", "admin_camara", "super_admin"]);
+
+// Public and TV routes do not require HTTP auth; TVs authenticate over sockets.
+router.get("/status/:camaraId", falaAoVivoController.getStatusFala);
+router.post("/notify", falaAoVivoController.notifyFalaAoVivo);
+
+router.post(
+	"/tempo-esgotado/:historicoId",
+	canMarkTempoEsgotado,
+	falaAoVivoController.markTempoEsgotado
+);
+
+module.exports = router;

--- a/src/routes/livestreamRoutes.js
+++ b/src/routes/livestreamRoutes.js
@@ -1,0 +1,28 @@
+/**
+ * Livestream routes for querying YouTube livestream state and triggering
+ * manual checks.
+ */
+
+const express = require('express');
+const router = express.Router();
+const livestreamController = require('../controllers/livestreamController');
+
+// Log each livestream route request for operational troubleshooting.
+router.use((req, res, next) => {
+    console.log(`[LIVESTREAM_ROUTES] ${new Date().toISOString()} - ${req.method} ${req.originalUrl}`);
+    next();
+});
+
+router.get('/status', livestreamController.getSystemStatus);
+
+router.get('/camara/:camaraId/current', livestreamController.getCurrentLivestream);
+
+router.get('/camara/:camaraId/last', livestreamController.getLastLivestream);
+
+router.get('/camara/:camaraId/display', livestreamController.getDisplayLivestream);
+
+router.get('/camara/:camaraId', livestreamController.getCamaraLivestreams);
+
+router.post('/camara/:camaraId/check', livestreamController.forceCheckCamara);
+
+module.exports = router;


### PR DESCRIPTION
Implements the endpoints for managing live broadcasts and active speaker control for physical TV displays. Includes endpoints to fetch active streams via the YouTube API.