### PR TITLE
build(deploy): add infrastructure configuration and reverse proxy

### DIFF
--- a/deploy/nginx/legislanet.com.br.conf
+++ b/deploy/nginx/legislanet.com.br.conf
@@ -1,0 +1,74 @@
+# Nginx template - LegislaNet (legislanet.com.br)
+# - Web backend: 127.0.0.1:3000
+# - Tablet backend: 127.0.0.1:3003 (proxied under /tablet-api)
+#
+# Usage on VPS:
+#   sudo cp /opt/legislanet/deploy/nginx/legislanet.com.br.conf /etc/nginx/sites-available/legislanet
+#   sudo ln -s /etc/nginx/sites-available/legislanet /etc/nginx/sites-enabled/legislanet
+#   sudo nginx -t && sudo systemctl reload nginx
+
+server {
+  listen 80;
+  server_name legislanet.com.br www.legislanet.com.br;
+
+  # Web backend (Socket.IO)
+  location /socket.io/ {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+  }
+
+  # Web backend (HTTP)
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # Tablet backend (Socket.IO) under /tablet-api
+  location /tablet-api/socket.io/ {
+    proxy_pass http://127.0.0.1:3003/socket.io/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+  }
+
+  # Rota para Backend do Tablet (Porta 3003)
+  location /tablet-api/ {
+    proxy_pass http://localhost:3003/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # Rota para Downloads (APK e Version JSON) - Servido pelo Nginx para performance
+  location /downloads/ {
+    alias /opt/legislanet/Apps/tablet_backend/public/downloads/;
+    autoindex off;
+    expires 1h;
+    add_header Cache-Control "public, no-transform";
+  }
+}

--- a/deploy/nginx/legislanet.duckdns.org.conf
+++ b/deploy/nginx/legislanet.duckdns.org.conf
@@ -1,0 +1,65 @@
+# Nginx template - LegislaNet (DuckDNS)
+# - Web backend: 127.0.0.1:3000
+# - Tablet backend: 127.0.0.1:3003 (proxied under /tablet-api)
+#
+# Usage on VPS:
+#   sudo cp /opt/legislanet/deploy/nginx/legislanet.duckdns.org.conf /etc/nginx/sites-available/legislanet
+#   sudo sed -i 's/legislanet\.duckdns\.org/SEU_DOMINIO_AQUI/g' /etc/nginx/sites-available/legislanet
+#   sudo ln -s /etc/nginx/sites-available/legislanet /etc/nginx/sites-enabled/legislanet
+#   sudo nginx -t && sudo systemctl reload nginx
+
+server {
+  listen 80;
+  server_name legislanet.duckdns.org;
+
+  # Web backend (Socket.IO)
+  location /socket.io/ {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+  }
+
+  # Web backend (HTTP)
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  # Tablet backend (Socket.IO) under /tablet-api
+  location /tablet-api/socket.io/ {
+    proxy_pass http://127.0.0.1:3003/socket.io/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+  }
+
+  location /tablet-api/ {
+    proxy_pass http://127.0.0.1:3003/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}


### PR DESCRIPTION
- Add NGINX configuration files to manage domains (legislanet.com.br and duckdns.org).
- Prepare backend deployment infrastructure in the cloud.
- Consolidate essential deployment sprint artifacts.